### PR TITLE
chore: remove accidentally committed binary, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 icinga-webhook-bridge
 webhook-bridge
+icinga-alert-forge
 *.exe
 *.dll
 *.so


### PR DESCRIPTION
The compiled binary `icinga-alert-forge` was accidentally committed as part of PR #55 (Prometheus integration). This PR removes it from git tracking and adds it to `.gitignore` alongside the existing binary entries.