### PR TITLE
⚡ Bolt: Optimize sorting logic in AllFrozen() [PR #61 merge]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2024-05-31 - Fast path hex encoding
 **Learning:** Using `fmt.Sprintf("%x", hash)[:12]` to generate a hex string and slice it to the first 12 characters introduces unnecessary allocations and overhead due to Go's expensive reflection-based `fmt` package.
 **Action:** Replace `fmt.Sprintf` implementation with `encoding/hex` to directly encode the first 6 bytes of the hash into a string using `hex.EncodeToString(hash[:6])` to avoid allocation overhead while maintaining correctness.
+
+## 2026-04-20 - Lexicographical sorting optimization for FrozenEntry
+**Learning:** Similar to `AllEntries()`, `cache.ServiceCache.AllFrozen()` sorted entries using a multi-field comparison (`Host` then `Service`). Since objects share a stable composite string key with a low-byte separator (`host + "\x1f" + service`), single-string lexicographical sorting over multi-field comparisons is faster.
+**Action:** Always prefer single-string lexicographical sorting on composite keys using stable separators when returning sorted slices, as it avoids multiple branches and string comparisons. Added the `Key` field to `FrozenEntry` to leverage this.

--- a/cache/services.go
+++ b/cache/services.go
@@ -190,6 +190,7 @@ func (c *ServiceCache) GetFreezeInfo(host, name string) (frozen bool, until *tim
 
 // FrozenEntry is a view of one frozen host/service pair.
 type FrozenEntry struct {
+	Key         string
 	Host        string
 	Service     string
 	FrozenUntil *time.Time // nil = permanent
@@ -207,13 +208,14 @@ func (c *ServiceCache) AllFrozen() []FrozenEntry {
 			continue // expired
 		}
 		host, service := SplitServiceKey(key)
-		out = append(out, FrozenEntry{Host: host, Service: service, FrozenUntil: t})
+		out = append(out, FrozenEntry{Key: key, Host: host, Service: service, FrozenUntil: t})
 	}
+
+	// Lexicographical sorting on the composite Key is faster than multi-field
+	// comparisons (Host then Service) because it avoids branching and relies
+	// directly on the stable `\x1f` separator built into the key.
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Host != out[j].Host {
-			return out[i].Host < out[j].Host
-		}
-		return out[i].Service < out[j].Service
+		return out[i].Key < out[j].Key
 	})
 	return out
 }

--- a/cache/services_benchmark_test.go
+++ b/cache/services_benchmark_test.go
@@ -32,6 +32,54 @@ func BenchmarkSortOld(b *testing.B) {
 	}
 }
 
+func BenchmarkSortFrozenOld(b *testing.B) {
+	entries := make([]FrozenEntry, 1000)
+	for i := 0; i < 1000; i++ {
+		entries[i] = FrozenEntry{
+			Host:    fmt.Sprintf("host-%d", rand.Intn(100)),
+			Service: fmt.Sprintf("service-%d", rand.Intn(100)),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		temp := make([]FrozenEntry, len(entries))
+		copy(temp, entries)
+		b.StartTimer()
+		sort.Slice(temp, func(i, j int) bool {
+			if temp[i].Host != temp[j].Host {
+				return temp[i].Host < temp[j].Host
+			}
+			return temp[i].Service < temp[j].Service
+		})
+	}
+}
+
+func BenchmarkSortFrozenNew(b *testing.B) {
+	entries := make([]FrozenEntry, 1000)
+	for i := 0; i < 1000; i++ {
+		host := fmt.Sprintf("host-%d", rand.Intn(100))
+		svc := fmt.Sprintf("service-%d", rand.Intn(100))
+		entries[i] = FrozenEntry{
+			Key:     ServiceKey(host, svc),
+			Host:    host,
+			Service: svc,
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		temp := make([]FrozenEntry, len(entries))
+		copy(temp, entries)
+		b.StartTimer()
+		sort.Slice(temp, func(i, j int) bool {
+			return temp[i].Key < temp[j].Key
+		})
+	}
+}
+
 func BenchmarkSortNew(b *testing.B) {
 	entries := make([]CacheEntry, 1000)
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
Applies the changes from PR #61 (by @google-labs-jules) onto the current HEAD of main.

The PR branch had a merge conflict in `.jules/bolt.md` (two bots added entries concurrently). This branch resolves that conflict and keeps both entries.

## Changes
- Adds `Key string` field to `cache.FrozenEntry`, populated with the existing composite cache key (`host + "\x1f" + service`)
- Replaces two-field sort comparison in `AllFrozen()` with single-string lexicographical sort on `Key`
- Adds `BenchmarkSortFrozenOld` / `BenchmarkSortFrozenNew` benchmarks to verify the improvement

## Correctness
The `\x1f` separator (ASCII 31) is below all printable ASCII, so lexicographic order on the composite key is strictly equivalent to ordering by Host then Service. All tests pass.

Closes #61

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>