### PR TITLE
docs: fix installation guide — correct binary name, paths, compose usage, and missing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ ICINGA2_TLS_SKIP_VERIFY=false
 # ── TARGETS / ROUTING ───────────────────────────────────────────
 # Modern configuration model:
 # one target = one managed dummy host in Icinga2
-# one target can have many API keys
+# one target can have many API keys (comma-separated)
 # each target can define its own notification users/groups/states
 # SOURCE is optional and defaults to the normalized target ID
 # API keys must be unique across all targets
@@ -59,6 +59,15 @@ IAF_TARGET_TEAM_B_NOTIFICATION_HOST_STATES=down
 HISTORY_FILE=/var/log/webhook-bridge/history.jsonl
 HISTORY_MAX_ENTRIES=10000
 
+# ── RETRY QUEUE ──────────────────────────────────────────────────
+# Retries failed Icinga2 calls with exponential backoff.
+RETRY_QUEUE_ENABLED=true
+RETRY_QUEUE_FILE=/var/log/webhook-bridge/retry-queue.json
+RETRY_QUEUE_MAX_SIZE=1000
+RETRY_QUEUE_RETRY_BASE_SEC=5
+RETRY_QUEUE_RETRY_MAX_SEC=300
+RETRY_QUEUE_CHECK_INTERVAL_SEC=10
+
 # ── CACHE ────────────────────────────────────────────────────────
 CACHE_TTL_MINUTES=60
 
@@ -78,3 +87,26 @@ RATELIMIT_MAX_QUEUE=100
 # ── PROMETHEUS METRICS ──────────────────────────────────────────
 METRICS_ENABLED=true
 METRICS_TOKEN=
+
+# ── AUDIT LOG ────────────────────────────────────────────────────
+# Disabled by default. Enable to record all webhook and admin actions.
+AUDIT_LOG_ENABLED=false
+AUDIT_LOG_FILE=/var/log/webhook-bridge/audit.log
+AUDIT_LOG_FORMAT=json
+
+# ── HEALTH CHECK (Icinga self-monitoring) ────────────────────────
+# Registers a passive check in Icinga2 to monitor the bridge itself.
+# Disabled by default.
+# HEALTH_CHECK_ENABLED=false
+# HEALTH_CHECK_INTERVAL_SEC=60
+# HEALTH_CHECK_REGISTER=false
+# HEALTH_CHECK_SERVICE_NAME=IcingaAlertForge
+# HEALTH_CHECK_TARGET_HOST=
+
+# ── DASHBOARD CONFIG MODE ────────────────────────────────────────
+# Set CONFIG_IN_DASHBOARD=true to manage all settings from the
+# Beauty Panel UI instead of environment variables.
+# On first start, env vars are migrated automatically to config.json.
+# CONFIG_IN_DASHBOARD=false
+# CONFIG_FILE_PATH=/var/log/webhook-bridge/config.json
+# CONFIG_ENCRYPTION_KEY=

--- a/docs/guides/fast-track-deployment.md
+++ b/docs/guides/fast-track-deployment.md
@@ -80,30 +80,42 @@ Example:
 - `/webhook` + first key → `home-critical`
 - `/webhook` + second key → `home-warning`
 
-## Run It With Docker
+## Run It With Docker Compose (Recommended)
+
+```bash
+docker compose up -d --build
+```
+
+Check logs:
+
+```bash
+docker compose logs -f webhook-bridge
+```
+
+## Run It With Docker (without Compose)
 
 Build the image:
 
 ```bash
-docker build -t icinga-alert-forge .
+docker build -t webhook-bridge .
 ```
 
 Run it:
 
 ```bash
 docker run -d \
-  --name icinga-alert-forge \
+  --name webhook-bridge \
   --restart unless-stopped \
   -p 8080:8080 \
   --env-file .env \
   -v iaf-logs:/var/log/webhook-bridge \
-  icinga-alert-forge
+  webhook-bridge
 ```
 
 Check logs:
 
 ```bash
-docker logs -f icinga-alert-forge
+docker logs -f webhook-bridge
 ```
 
 What you want to see:

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,10 +1,12 @@
 # Installation Guide
 
-This guide covers the two main ways to deploy IcingaAlertForge: using Docker (recommended) or as a standalone binary.
+This guide covers the two main ways to deploy IcingaAlertForge: using Docker Compose (recommended) or as a standalone binary on the host.
 
-## Prerequisites: Icinga2 API User
+---
 
-Before deploying the bridge you need an API user in Icinga2 with the right permissions.
+## Step 0: Prerequisites — Icinga2 API User
+
+Before deploying the bridge, create an API user in Icinga2 with the required permissions.
 
 Create or edit a file in `/etc/icinga2/conf.d/`, for example `iaf-apiuser.conf`:
 
@@ -29,141 +31,197 @@ Then reload Icinga2:
 sudo systemctl reload icinga2
 ```
 
-The `objects/create/Host` and `objects/query/Host` permissions are only required when `ICINGA2_HOST_AUTO_CREATE=true`. If you create dummy hosts manually you can omit them.
+> The `objects/create/Host` and `objects/query/Host` permissions are only needed when `ICINGA2_HOST_AUTO_CREATE=true`. If you create dummy hosts manually, you can omit them.
 
 ---
 
-## A. Docker Deployment (Recommended)
+## A. Docker Compose (Recommended)
 
-Docker is the easiest way to deploy IcingaAlertForge with all its dependencies and proper isolation.
+### Requirements
 
-### Prerequisites
-- Docker and Docker Compose installed.
-- Access to an Icinga2 REST API (see section above).
+- Docker Engine 20.10+ and Docker Compose v2 (`docker compose` command)
+- Access to the Icinga2 REST API (port 5665)
+- Git
 
-### `docker-compose.yml` Example
+### 1. Clone the Repository
 
-Create a `docker-compose.yml` file with the following content:
-
-```yaml
-version: '3.8'
-
-services:
-  icinga-alertforge:
-    image: icinga-alertforge:latest
-    container_name: icinga-alertforge
-    restart: unless-stopped
-    ports:
-      - "8080:8080"
-    environment:
-      # --- Icinga2 Connection ---
-      - ICINGA2_HOST=https://icinga2:5665
-      - ICINGA2_USER=icinga-alertforge
-      - ICINGA2_PASS=secret-api-pass
-      - ICINGA2_TLS_SKIP_VERIFY=false
-      - ICINGA2_HOST_AUTO_CREATE=true
-
-      # --- Admin Credentials ---
-      - ADMIN_USER=admin
-      - ADMIN_PASS=change-me-immediately
-
-      # --- Routing: one block per logical webhook destination ---
-      # API key selects the target; all senders use the same /webhook URL.
-      - IAF_TARGET_TEAM_A_HOST_NAME=a-dummy-dev
-      - IAF_TARGET_TEAM_A_HOST_DISPLAY=Team A Alerts
-      - IAF_TARGET_TEAM_A_API_KEYS=replace-with-long-random-key
-      - IAF_TARGET_TEAM_A_NOTIFICATION_GROUPS=sms-admins
-      - IAF_TARGET_TEAM_A_NOTIFICATION_SERVICE_STATES=critical,warning
-
-      # Add more blocks for additional teams:
-      # - IAF_TARGET_TEAM_B_HOST_NAME=b-dummy-dev
-      # - IAF_TARGET_TEAM_B_API_KEYS=replace-with-second-key
-      # - IAF_TARGET_TEAM_B_NOTIFICATION_GROUPS=mail-admins
-
-      # --- Configuration Mode (optional dashboard config) ---
-      - CONFIG_IN_DASHBOARD=false
-      # Set to true to manage config from the Beauty Panel instead of env vars.
-      # If enabled, uncomment and set these:
-      # - CONFIG_FILE_PATH=/var/lib/iaf/config.json
-      # - CONFIG_ENCRYPTION_KEY=my-secure-key-32-chars-long-!!!
-
-      # --- Persistence Paths ---
-      - HISTORY_FILE=/var/lib/iaf/history.jsonl
-      - RETRY_QUEUE_FILE=/var/lib/iaf/retry-queue.json
-      - AUDIT_LOG_ENABLED=false
-      - AUDIT_LOG_FILE=/var/lib/iaf/audit.log
-    volumes:
-      - iaf_data:/var/lib/iaf
-
-volumes:
-  iaf_data:
+```bash
+git clone https://github.com/dzaczek/IcingaAlertingForge.git
+cd IcingaAlertingForge
 ```
 
-### Deployment Steps
+### 2. Create the Environment File
 
-1. **Build the image:**
-    ```bash
-    git clone https://github.com/dzaczek/IcingaAlertingForge.git
-    cd IcingaAlertingForge
-    docker build -t icinga-alertforge .
-    ```
-2. **Configure environment:** Edit the `environment` section in `docker-compose.yml` with your actual Icinga2 details, secure passwords, and target blocks.
-3. **Start the container:**
-    ```bash
-    docker-compose up -d
-    ```
-4. **Verify:** Check the logs to ensure the bridge connected to Icinga2 successfully:
-    ```bash
-    docker logs -f icinga-alertforge
-    ```
-5. **Health Check:** Access `http://<host>:8080/health` to verify the service status.
+```bash
+cp .env.example .env
+```
+
+Open `.env` in your editor and fill in the required values:
+
+```bash
+# --- Required ---
+ICINGA2_HOST=https://icinga2.example.com:5665   # your Icinga2 URL
+ICINGA2_USER=icinga-alertforge                   # API user from Step 0
+ICINGA2_PASS=secret-api-pass                     # API password from Step 0
+ICINGA2_HOST_AUTO_CREATE=true                    # creates dummy hosts automatically
+
+# --- Admin panel credentials (change these!) ---
+ADMIN_USER=admin
+ADMIN_PASS=change-me-immediately
+
+# --- Webhook routing: one block per team / source ---
+IAF_TARGET_TEAM_A_HOST_NAME=a-dummy-dev
+IAF_TARGET_TEAM_A_HOST_DISPLAY=Team A Alerts
+IAF_TARGET_TEAM_A_API_KEYS=replace-with-long-random-key
+IAF_TARGET_TEAM_A_NOTIFICATION_GROUPS=sms-admins
+IAF_TARGET_TEAM_A_NOTIFICATION_SERVICE_STATES=critical,warning
+
+# Add more teams by copying the block above with a different prefix,
+# for example IAF_TARGET_TEAM_B_*
+```
+
+> **TLS note:** If your Icinga2 uses a self-signed certificate, set `ICINGA2_TLS_SKIP_VERIFY=true`. For production, keep it `false` and ensure your CA is trusted.
+
+For the full list of all available variables, see the [Configuration Reference](../docs/guides/configuration.md).
+
+### 3. Start the Bridge
+
+```bash
+docker compose up -d --build
+```
+
+Docker Compose will build the image from the local `Dockerfile` and start the container. The service runs on port `8080` by default.
+
+### 4. Check Startup Logs
+
+```bash
+docker compose logs -f webhook-bridge
+```
+
+A successful startup looks like:
+
+```
+{"level":"info","msg":"IcingaAlertForge starting","version":"..."}
+{"level":"info","msg":"Icinga2 connection OK"}
+{"level":"info","msg":"Listening on 0.0.0.0:8080"}
+```
+
+If you see `connection refused` or `401 Unauthorized`, check `ICINGA2_HOST`, `ICINGA2_USER`, and `ICINGA2_PASS` in your `.env`.
+
+### 5. Verify the Health Endpoint
+
+```bash
+curl -s http://localhost:8080/health
+```
+
+Expected response: `{"status":"ok"}` (or a JSON object with component statuses).
+
+### 6. Open the Admin Panel
+
+Navigate to:
+
+```
+http://<your-server>:8080/status/beauty?admin=1
+```
+
+Log in with `ADMIN_USER` / `ADMIN_PASS` from your `.env`.
+
+You should see the LCARS dashboard. The **Overview** section shows totals, **Icinga Mgmt** shows managed hosts, and **Settings** (when `CONFIG_IN_DASHBOARD=true`) lets you manage configuration from the UI.
 
 ---
 
-## B. Manual / Binary Installation
+## B. Panel Configuration After Startup
 
-Use this method if you prefer to run IcingaAlertForge as a native system service.
+### Option 1: Environment variables (default)
 
-### Prerequisites
-- Go 1.24 or newer.
-- A writeable directory for logs and configuration.
+Everything is already configured through `.env`. No further action needed in the panel. Restart the container after changing `.env`:
+
+```bash
+docker compose restart webhook-bridge
+```
+
+### Option 2: Dashboard config mode (manage config from the UI)
+
+Enable it by adding to `.env`:
+
+```env
+CONFIG_IN_DASHBOARD=true
+# Optional: provide your own encryption key (32+ chars), or one is auto-generated
+# CONFIG_ENCRYPTION_KEY=my-secure-key-32-chars-long-!!!
+```
+
+On first startup, the bridge migrates your current env vars into a persistent JSON file on the Docker volume. After that, you can change all settings from the **Settings** tab in the admin panel without touching `.env` or restarting.
+
+> Secrets (Icinga2 password, API keys, admin password) are encrypted at rest with AES-256-GCM.
+
+To access Settings:
+
+1. Go to `http://<your-server>:8080/status/beauty?admin=1`
+2. Click the **Settings** tab in the sidebar
+3. Sections available:
+   - **Icinga2 Connection** — host URL, credentials, TLS toggle, test button
+   - **Targets & Webhooks** — add/delete targets, generate and copy API keys
+   - **Admin Credentials** — change admin username and password
+   - **History & Cache** — file paths, max entries, cache TTL
+   - **Logging** — log level and format
+   - **Rate Limiting** — concurrency and queue limits
+   - **Export / Import** — full config backup and restore as JSON
+
+---
+
+## C. Connect Grafana
+
+After the bridge is running, connect Grafana:
+
+1. In Grafana, go to **Alerting → Contact points → Add contact point**
+2. Set **Integration** to `Webhook`
+3. Set **URL** to `http://<your-server>:8080/webhook`
+4. Under **HTTP Headers**, add:
+   - Key: `X-API-Key`
+   - Value: the key from `IAF_TARGET_<ID>_API_KEYS` in your `.env`
+5. Click **Test** → **Send test notification**
+6. Open the admin panel — you should see the test alert in **Alerts** and **Real-time Webhook Flow**
+7. In Icinga2, a new service named `TestAlert` should appear on the target dummy host
+
+For the full Grafana integration walkthrough, see [Grafana Integration Setup](Grafana-Setup).
+
+---
+
+## D. Manual / Binary Installation
+
+Use this method only if you cannot use Docker.
+
+### Requirements
+
+- Go 1.24 or newer
+- A writable directory for data and configuration
 
 ### 1. Build from Source
 
 ```bash
 git clone https://github.com/dzaczek/IcingaAlertingForge.git
 cd IcingaAlertingForge
-go build -o icinga-alert-forge .
+go build -o webhook-bridge .
 ```
 
 ### 2. Configure Environment
 
-Copy the example and edit it:
-
 ```bash
 cp .env.example /opt/iaf/.env
+# Edit /opt/iaf/.env with your actual values (see Section A, Step 2)
 ```
 
-Minimum required settings:
+### 3. Create Directories and User
 
-```env
-ICINGA2_HOST=https://icinga2:5665
-ICINGA2_USER=icinga-alertforge
-ICINGA2_PASS=secret-api-pass
-ICINGA2_HOST_AUTO_CREATE=true
-ADMIN_USER=admin
-ADMIN_PASS=secure-admin-pass
-
-IAF_TARGET_TEAM_A_HOST_NAME=a-dummy-dev
-IAF_TARGET_TEAM_A_HOST_DISPLAY=Team A Alerts
-IAF_TARGET_TEAM_A_API_KEYS=replace-with-long-random-key
-IAF_TARGET_TEAM_A_NOTIFICATION_GROUPS=sms-admins
-IAF_TARGET_TEAM_A_NOTIFICATION_SERVICE_STATES=critical,warning
+```bash
+sudo useradd -r -s /bin/false iaf
+sudo mkdir -p /opt/iaf /var/log/webhook-bridge
+sudo cp webhook-bridge /opt/iaf/
+sudo cp .env.example /opt/iaf/.env
+sudo chown -R iaf:iaf /opt/iaf /var/log/webhook-bridge
 ```
 
-Each `IAF_TARGET_<ID>_*` block creates one logical webhook destination. See [Configuration](../docs/guides/configuration.md) for the full reference.
-
-### 3. Running as a Systemd Service
+### 4. Create a Systemd Service
 
 Create `/etc/systemd/system/icinga-alertforge.service`:
 
@@ -178,7 +236,7 @@ User=iaf
 Group=iaf
 WorkingDirectory=/opt/iaf
 EnvironmentFile=/opt/iaf/.env
-ExecStart=/opt/iaf/icinga-alert-forge
+ExecStart=/opt/iaf/webhook-bridge
 Restart=always
 RestartSec=10
 
@@ -186,40 +244,39 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
-### 4. Enable and Start
+### 5. Enable and Start
 
 ```bash
-# Create user and set permissions
-sudo useradd -r -s /bin/false iaf
-sudo mkdir -p /opt/iaf /var/log/webhook-bridge
-sudo cp icinga-alert-forge /opt/iaf/
-sudo cp .env.example /opt/iaf/.env
-sudo chown -R iaf:iaf /opt/iaf /var/log/webhook-bridge
-
-# Edit /opt/iaf/.env with your settings, then:
 sudo systemctl daemon-reload
 sudo systemctl enable icinga-alertforge
 sudo systemctl start icinga-alertforge
 ```
 
-### 5. Verification
-
-Monitor the systemd logs:
+### 6. Verify
 
 ```bash
 journalctl -u icinga-alertforge -f
-```
-
-Check health:
-
-```bash
 curl -s http://localhost:8080/health
 ```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `connection refused` on health check | Container not started or wrong port | Check `docker compose ps` and `ADMIN_PASS` |
+| `401 Unauthorized` in bridge logs | Wrong Icinga2 credentials | Check `ICINGA2_USER` / `ICINGA2_PASS` in `.env` |
+| `502 Bad Gateway` from Grafana | Bridge cannot reach Icinga2 port 5665 | Check network / firewall between bridge and Icinga2 |
+| Service not created in Icinga2 | Target host missing or wrong API key | Check `ICINGA2_HOST_AUTO_CREATE=true` and that the API key in Grafana matches `.env` |
+| Panel shows no data | Browser cache or wrong admin URL | Use `?admin=1` suffix and clear browser cache |
+| `tls: failed to verify certificate` | Self-signed Icinga2 cert | Set `ICINGA2_TLS_SKIP_VERIFY=true` (dev only) |
 
 ---
 
 ## Next Steps
 
 - [Grafana Integration Setup](Grafana-Setup) — connect Grafana contact points
-- [Configuration reference](../docs/guides/configuration.md) — all environment variables
+- [Configuration Reference](../docs/guides/configuration.md) — all environment variables explained
+- [Beauty Panel](../docs/guides/beauty-panel.md) — admin dashboard guide
 - [Fast Track Deployment](../docs/guides/fast-track-deployment.md) — quick smoke test


### PR DESCRIPTION
## Summary

The existing installation guide had several critical errors that would prevent a client from deploying the project successfully.

**Bugs fixed:**

- **Wrong binary name** — docs said `icinga-alert-forge`, Dockerfile builds `webhook-bridge`
- **Fake docker-compose in docs** — Installation.md showed a made-up compose with `image: icinga-alertforge:latest` (doesn't exist), wrong volume path `/var/lib/iaf` instead of `/var/log/webhook-bridge`, wrong service/container name
- **Wrong deployment steps** — docs told users to `docker build` separately before `docker-compose up`, but the real compose has `build: .` built in
- **Path inconsistency** — `CONFIG_FILE_PATH`, `RETRY_QUEUE_FILE`, etc. had different defaults in docs vs actual code
- **Missing env vars in `.env.example`** — `RETRY_QUEUE_*`, `AUDIT_LOG_*`, `HEALTH_CHECK_*`, `CONFIG_IN_DASHBOARD` were all absent
- **Wrong binary in systemd service** — `ExecStart` pointed to `icinga-alert-forge` instead of `webhook-bridge`

**New in Installation.md:**
- Complete Docker Compose walkthrough with correct service names and paths
- Panel configuration section (Option 1: env vars, Option 2: `CONFIG_IN_DASHBOARD=true`)
- Grafana connection steps inline
- Troubleshooting table covering the most common failure modes

## Test plan

- [ ] `docker compose up -d --build` from a fresh clone works end to end
- [ ] Health endpoint responds at `:8080/health`
- [ ] Admin panel accessible at `:8080/status/beauty?admin=1`
- [ ] `.env.example` covers all variables present in `config/config.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)