### PR TITLE
fix: resolve data races, lock contention, and DoS vectors from production audit

### DIFF
--- a/handler/admin.go
+++ b/handler/admin.go
@@ -448,6 +448,7 @@ func (h *AdminHandler) HandleDebugToggle(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var body struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -645,6 +646,7 @@ func (h *AdminHandler) HandleCreateUser(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var body struct {
 		Username string `json:"username"`
 		Password string `json:"password"`

--- a/health/checker.go
+++ b/health/checker.go
@@ -153,6 +153,8 @@ func (c *Checker) runCheck() {
 
 	healthy := c.status.Healthy
 	consecutiveFails := c.status.ConsecutiveFails
+	totalChecks := c.status.TotalChecks
+	totalFailures := c.status.TotalFailures
 	c.mu.Unlock()
 
 	// Report to Icinga2 if self-registration is enabled
@@ -162,11 +164,11 @@ func (c *Checker) runCheck() {
 		if healthy {
 			exitStatus = 0
 			message = fmt.Sprintf("OK: Bridge healthy, Icinga2 API reachable | checks=%d failures=%d",
-				c.status.TotalChecks, c.status.TotalFailures)
+				totalChecks, totalFailures)
 		} else {
 			exitStatus = 2
 			message = fmt.Sprintf("CRITICAL: Icinga2 API unreachable for %d consecutive checks | checks=%d failures=%d",
-				consecutiveFails, c.status.TotalChecks, c.status.TotalFailures)
+				consecutiveFails, totalChecks, totalFailures)
 		}
 
 		if sendErr := c.api.SendCheckResult(c.cfg.TargetHost, c.cfg.ServiceName, exitStatus, message); sendErr != nil {

--- a/history/logger.go
+++ b/history/logger.go
@@ -21,7 +21,7 @@ import (
 
 // Logger provides thread-safe JSONL history logging with rotation and filtering.
 type Logger struct {
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	filePath    string
 	maxEntries  int
 	appendCount atomic.Int64 // tracks appends since last rotation check
@@ -129,8 +129,8 @@ type QueryFilter struct {
 
 // Query returns history entries matching the filter, ordered newest-first.
 func (l *Logger) Query(filter QueryFilter) ([]models.HistoryEntry, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 
 	var matched []models.HistoryEntry
 	var matchedPos int


### PR DESCRIPTION
## Summary
- **health/checker.go**: Fix data race — capture `TotalChecks`/`TotalFailures` inside the lock section instead of reading them unprotected outside `c.mu`
- **history/logger.go**: Fix lock contention — change `sync.Mutex` to `sync.RWMutex`, use `RLock()` in `Query()` so history queries don't block alert processing (`Append`)
- **handler/admin.go**: Fix DoS vectors — add `http.MaxBytesReader` on `HandleCreateUser` and `HandleDebugToggle` endpoints

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — clean compilation