### PR TITLE
test(phase-2b): handler tests — 57.7% → 70.3% coverage

### DIFF
--- a/handler/admin_gap_test.go
+++ b/handler/admin_gap_test.go
@@ -1,0 +1,251 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"icinga-webhook-bridge/config"
+	"icinga-webhook-bridge/icinga"
+)
+
+// ── firstHostName ──────────────────────────────────────────────────────────
+
+func TestFirstHostName(t *testing.T) {
+	if got := firstHostName(nil); got != "" {
+		t.Errorf("nil → %q, want empty", got)
+	}
+	if got := firstHostName([]string{}); got != "" {
+		t.Errorf("empty → %q, want empty", got)
+	}
+	if got := firstHostName([]string{"a"}); got != "a" {
+		t.Errorf("single → %q, want a", got)
+	}
+	if got := firstHostName([]string{"a", "b"}); got != "ALL TARGETS" {
+		t.Errorf("multi → %q, want ALL TARGETS", got)
+	}
+}
+
+// ── targetHostNames ────────────────────────────────────────────────────────
+
+func TestTargetHostNames(t *testing.T) {
+	targets := map[string]config.TargetConfig{
+		"z": {ID: "z", HostName: "zulu"},
+		"a": {ID: "a", HostName: "alpha"},
+	}
+	names := targetHostNames(targets)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d", len(names))
+	}
+	// sorted alphabetically
+	if names[0] != "alpha" || names[1] != "zulu" {
+		t.Errorf("expected sorted [alpha, zulu], got %v", names)
+	}
+}
+
+// ── HandleClearHistory ─────────────────────────────────────────────────────
+
+func TestAdmin_HandleClearHistory_Gaps(t *testing.T) {
+	h, _ := testAdminHandler(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	t.Run("history nil", func(t *testing.T) {
+		// Set History to nil after testAdminHandler creates it
+		hNil := *h
+		hNil.History = nil
+		req := httptest.NewRequest(http.MethodPost, "/admin/history/clear", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		hNil.HandleClearHistory(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500 for nil history, got %d", rr.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/history/clear", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleClearHistory(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+}
+
+// ── HandleDebugToggle ──────────────────────────────────────────────────────
+
+func TestAdmin_HandleDebugToggle_Gaps(t *testing.T) {
+	h, _ := testAdminHandler(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	t.Run("debug ring nil", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/debug/toggle", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDebugToggle(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500 for nil debug ring, got %d", rr.Code)
+		}
+	})
+
+	t.Run("GET returns enabled state", func(t *testing.T) {
+		h.DebugRing = icinga.NewDebugRing()
+		req := httptest.NewRequest(http.MethodGet, "/admin/debug/toggle", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDebugToggle(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("POST invalid body", func(t *testing.T) {
+		h.DebugRing = icinga.NewDebugRing()
+		req := httptest.NewRequest(http.MethodPost, "/admin/debug/toggle", bytes.NewBufferString("not-json"))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDebugToggle(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rr.Code)
+		}
+	})
+
+	t.Run("POST enables debug", func(t *testing.T) {
+		h.DebugRing = icinga.NewDebugRing()
+		body, _ := json.Marshal(map[string]bool{"enabled": true})
+		req := httptest.NewRequest(http.MethodPost, "/admin/debug/toggle", bytes.NewBuffer(body))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDebugToggle(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		h.DebugRing = icinga.NewDebugRing()
+		req := httptest.NewRequest(http.MethodPut, "/admin/debug/toggle", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDebugToggle(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+}
+
+// ── HandleDeleteService ────────────────────────────────────────────────────
+
+func TestAdmin_HandleDeleteService_Gaps(t *testing.T) {
+	mockAPI := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// Return service info indicating it's managed by IAF
+			w.Write([]byte(`{"results":[{"attrs":{"managed_by":"IcingaAlertingForge","check_command":"dummy"}}]}`))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results":[{"code":200}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results":[]}`))
+	}
+	h, _ := testAdminHandler(t, mockAPI)
+
+	t.Run("valid delete with mock", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/admin/services/svc?host=host-a", nil)
+		req.URL.Path = "/admin/services/svc"
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDeleteService(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/services/svc?host=h", nil)
+		req.URL.Path = "/admin/services/svc"
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDeleteService(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+
+	t.Run("missing service name", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/admin/services/?host=host-a", nil)
+		req.URL.Path = "/admin/services/"
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleDeleteService(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for missing service, got %d", rr.Code)
+		}
+	})
+}
+
+// ── HandleBulkDelete ───────────────────────────────────────────────────────
+
+func TestAdmin_HandleBulkDelete_Gaps(t *testing.T) {
+	mockAPI := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"results":[{"code":200}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results":[]}`))
+	}
+	h, _ := testAdminHandler(t, mockAPI)
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/services/bulk-delete", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleBulkDelete(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+
+	t.Run("invalid JSON body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/admin/services/bulk-delete", bytes.NewBufferString("bad"))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleBulkDelete(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("empty services list", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{"services": []any{}})
+		req := httptest.NewRequest(http.MethodPost, "/admin/services/bulk-delete", bytes.NewBuffer(body))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleBulkDelete(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rr.Code)
+		}
+	})
+
+	t.Run("valid bulk delete", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"services": []string{"svc1", "svc2"},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/admin/services/bulk-delete", bytes.NewBuffer(body))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleBulkDelete(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/handler/dashboard_minimal_test.go
+++ b/handler/dashboard_minimal_test.go
@@ -15,11 +15,11 @@ import (
 func TestDashboard_ServeHTTP_Basic(t *testing.T) {
 	histLogger, _ := history.NewLogger(filepath.Join(t.TempDir(), "hist.jsonl"), 100)
 	h := &DashboardHandler{
-		Cache:    cache.NewServiceCache(60),
-		History:  histLogger,
-		Metrics:  metrics.NewCollector(),
-		Targets:  map[string]config.TargetConfig{},
-		Version:  "test",
+		Cache:     cache.NewServiceCache(60),
+		History:   histLogger,
+		Metrics:   metrics.NewCollector(),
+		Targets:   map[string]config.TargetConfig{},
+		Version:   "test",
 		AdminPass: "test",
 	}
 

--- a/handler/dashboard_minimal_test.go
+++ b/handler/dashboard_minimal_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"icinga-webhook-bridge/cache"
+	"icinga-webhook-bridge/config"
+	"icinga-webhook-bridge/history"
+	"icinga-webhook-bridge/metrics"
+)
+
+func TestDashboard_ServeHTTP_Basic(t *testing.T) {
+	histLogger, _ := history.NewLogger(filepath.Join(t.TempDir(), "hist.jsonl"), 100)
+	h := &DashboardHandler{
+		Cache:    cache.NewServiceCache(60),
+		History:  histLogger,
+		Metrics:  metrics.NewCollector(),
+		Targets:  map[string]config.TargetConfig{},
+		Version:  "test",
+		AdminPass: "test",
+	}
+
+	t.Run("non-GET method returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+
+	t.Run("GET renders dashboard", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("GET with admin=1 without creds returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?admin=1", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rr.Code)
+		}
+	})
+}

--- a/handler/dashboard_status_test.go
+++ b/handler/dashboard_status_test.go
@@ -1,0 +1,181 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"icinga-webhook-bridge/history"
+	"icinga-webhook-bridge/models"
+	"icinga-webhook-bridge/rbac"
+)
+
+func TestToDashboardAlert(t *testing.T) {
+	base := models.HistoryEntry{
+		RequestID: "req-1",
+		SourceKey: "grafana",
+		HostName:  "host-a",
+		Mode:      "work",
+		Action:    "firing",
+		ExitStatus: 2,
+		IcingaOK:  true,
+		Error:     "",
+	}
+
+	t.Run("critical status", func(t *testing.T) {
+		da := toDashboardAlert(base)
+		if da.StatusLabel != "CRITICAL" {
+			t.Errorf("expected CRITICAL, got %s", da.StatusLabel)
+		}
+		if da.StatusClass != "critical" {
+			t.Errorf("expected critical class, got %s", da.StatusClass)
+		}
+	})
+
+	t.Run("warning status", func(t *testing.T) {
+		e := base
+		e.ExitStatus = 1
+		da := toDashboardAlert(e)
+		if da.StatusLabel != "WARNING" {
+			t.Errorf("expected WARNING, got %s", da.StatusLabel)
+		}
+		if da.StatusClass != "warning" {
+			t.Errorf("expected warning class, got %s", da.StatusClass)
+		}
+	})
+
+	t.Run("ok status", func(t *testing.T) {
+		e := base
+		e.ExitStatus = 0
+		da := toDashboardAlert(e)
+		if da.StatusLabel != "OK" {
+			t.Errorf("expected OK, got %s", da.StatusLabel)
+		}
+		if da.StatusClass != "ok" {
+			t.Errorf("expected ok class, got %s", da.StatusClass)
+		}
+	})
+
+	t.Run("test mode override", func(t *testing.T) {
+		e := base
+		e.Mode = "test"
+		da := toDashboardAlert(e)
+		if da.StatusLabel != "TEST" {
+			t.Errorf("expected TEST, got %s", da.StatusLabel)
+		}
+		if da.StatusClass != "test" {
+			t.Errorf("expected test class, got %s", da.StatusClass)
+		}
+	})
+
+	t.Run("manual mode suffix", func(t *testing.T) {
+		e := base
+		e.Mode = "manual"
+		da := toDashboardAlert(e)
+		if da.StatusLabel != "CRITICAL [MANUAL]" {
+			t.Errorf("expected 'CRITICAL [MANUAL]', got %s", da.StatusLabel)
+		}
+	})
+
+	t.Run("icinga error overrides class", func(t *testing.T) {
+		e := base
+		e.IcingaOK = false
+		da := toDashboardAlert(e)
+		if da.StatusClass != "error" {
+			t.Errorf("expected error class, got %s", da.StatusClass)
+		}
+	})
+
+	t.Run("error string overrides class", func(t *testing.T) {
+		e := base
+		e.Error = "something went wrong"
+		da := toDashboardAlert(e)
+		if da.StatusClass != "error" {
+			t.Errorf("expected error class, got %s", da.StatusClass)
+		}
+	})
+}
+
+func TestIsAdmin(t *testing.T) {
+	t.Run("no admin pass returns false", func(t *testing.T) {
+		h := &DashboardHandler{AdminPass: ""}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if h.isAdmin(req) {
+			t.Error("expected false when admin pass not set")
+		}
+	})
+
+	t.Run("no basic auth returns false", func(t *testing.T) {
+		h := &DashboardHandler{AdminUser: "admin", AdminPass: "secret"}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if h.isAdmin(req) {
+			t.Error("expected false without basic auth")
+		}
+	})
+
+	t.Run("correct credentials returns true", func(t *testing.T) {
+		h := &DashboardHandler{AdminUser: "admin", AdminPass: "secret"}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "secret")
+		if !h.isAdmin(req) {
+			t.Error("expected true with correct credentials")
+		}
+	})
+
+	t.Run("wrong password returns false", func(t *testing.T) {
+		h := &DashboardHandler{AdminUser: "admin", AdminPass: "secret"}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		if h.isAdmin(req) {
+			t.Error("expected false with wrong password")
+		}
+	})
+
+	t.Run("RBAC user returns true", func(t *testing.T) {
+		rbacMgr := rbac.New(nil)
+		rbacMgr.AddUser(rbac.User{Username: "user", Password: "pass", Role: rbac.RoleViewer})
+		h := &DashboardHandler{AdminUser: "admin", AdminPass: "secret", RBAC: rbacMgr}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("user", "pass")
+		if !h.isAdmin(req) {
+			t.Error("expected true for authenticated RBAC user")
+		}
+	})
+}
+
+func TestBuildSourceIPLists(t *testing.T) {
+	stats := history.HistoryStats{
+		BySourceIP: map[string]map[string]int{
+			"grafana": {
+				"10.0.0.1": 5,
+				"10.0.0.2": 3,
+				"10.0.0.3": 1,
+			},
+			"alertmanager": {
+				"192.168.1.1": 2,
+			},
+		},
+		BySourceIPLastSeen: map[string]map[string]time.Time{
+			"grafana": {
+				"10.0.0.1": time.Now(),
+			},
+		},
+	}
+
+	topIPs, lastIPs := buildSourceIPLists(stats)
+
+	if len(topIPs) != 2 {
+		t.Errorf("expected 2 sources in topIPs, got %d", len(topIPs))
+	}
+	if len(topIPs["grafana"]) != 3 {
+		t.Errorf("expected 3 entries for grafana, got %d", len(topIPs["grafana"]))
+	}
+	// First entry should be the highest count
+	if topIPs["grafana"][0].Count != 5 {
+		t.Errorf("expected highest count first, got %d", topIPs["grafana"][0].Count)
+	}
+	if len(lastIPs) != 2 {
+		t.Errorf("expected 2 sources in lastIPs, got %d", len(lastIPs))
+	}
+}

--- a/handler/dashboard_status_test.go
+++ b/handler/dashboard_status_test.go
@@ -13,14 +13,14 @@ import (
 
 func TestToDashboardAlert(t *testing.T) {
 	base := models.HistoryEntry{
-		RequestID: "req-1",
-		SourceKey: "grafana",
-		HostName:  "host-a",
-		Mode:      "work",
-		Action:    "firing",
+		RequestID:  "req-1",
+		SourceKey:  "grafana",
+		HostName:   "host-a",
+		Mode:       "work",
+		Action:     "firing",
 		ExitStatus: 2,
-		IcingaOK:  true,
-		Error:     "",
+		IcingaOK:   true,
+		Error:      "",
 	}
 
 	t.Run("critical status", func(t *testing.T) {

--- a/handler/settings_gap_test.go
+++ b/handler/settings_gap_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"icinga-webhook-bridge/configstore"
+	"icinga-webhook-bridge/metrics"
+	"icinga-webhook-bridge/rbac"
+)
+
+func TestSettings_checkAuth_Gaps(t *testing.T) {
+	store, _ := configstore.New(t.TempDir()+"/cfg.json", "test-key")
+	store.Update(configstore.StoredConfig{})
+
+	t.Run("wrong password for primary admin", func(t *testing.T) {
+		h := &SettingsHandler{User: "admin", Pass: "secret", Store: store}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		rr := httptest.NewRecorder()
+		if h.checkAuth(rr, req) {
+			t.Error("expected auth failure with wrong password")
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rr.Code)
+		}
+	})
+
+	t.Run("RBAC user with manage.config permission", func(t *testing.T) {
+		rbacMgr := rbac.New(nil)
+		rbacMgr.AddUser(rbac.User{Username: "rbacadmin", Password: "admin-pass", Role: rbac.RoleAdmin})
+		h := &SettingsHandler{User: "primary", Pass: "primarypass", Store: store, RBAC: rbacMgr}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("rbacadmin", "admin-pass")
+		rr := httptest.NewRecorder()
+		if !h.checkAuth(rr, req) {
+			t.Error("expected auth success for rbacadmin with manage.config")
+		}
+	})
+
+	t.Run("RBAC user without manage.config permission", func(t *testing.T) {
+		rbacMgr := rbac.New(nil)
+		rbacMgr.AddUser(rbac.User{Username: "viewer", Password: "view-pass", Role: rbac.RoleViewer})
+		h := &SettingsHandler{User: "admin", Pass: "secret", Store: store, RBAC: rbacMgr}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("viewer", "view-pass")
+		rr := httptest.NewRecorder()
+		if h.checkAuth(rr, req) {
+			t.Error("expected auth failure for viewer without manage.config")
+		}
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", rr.Code)
+		}
+	})
+
+	t.Run("RBAC user with wrong password", func(t *testing.T) {
+		rbacMgr := rbac.New(nil)
+		rbacMgr.AddUser(rbac.User{Username: "viewer", Password: "correct", Role: rbac.RoleViewer})
+		h := &SettingsHandler{User: "admin", Pass: "secret", Store: store, RBAC: rbacMgr}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("viewer", "wrong")
+		rr := httptest.NewRecorder()
+		if h.checkAuth(rr, req) {
+			t.Error("expected auth failure with wrong RBAC password")
+		}
+	})
+
+	t.Run("RBAC nil, wrong primary and no fallback", func(t *testing.T) {
+		h := &SettingsHandler{User: "admin", Pass: "secret", Store: store, RBAC: nil}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		rr := httptest.NewRecorder()
+		if h.checkAuth(rr, req) {
+			t.Error("expected auth failure")
+		}
+	})
+
+	t.Run("with metrics collector", func(t *testing.T) {
+		mc := metrics.NewCollector()
+		h := &SettingsHandler{User: "admin", Pass: "secret", Store: store, Metrics: mc}
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		rr := httptest.NewRecorder()
+		if h.checkAuth(rr, req) {
+			t.Error("expected auth failure with metrics")
+		}
+		// auth failure should be recorded
+	})
+}
+
+func TestSettings_HandleGetSettings_Gaps(t *testing.T) {
+	t.Run("no auth header returns 401", func(t *testing.T) {
+		h := testSettingsHandler(t)
+		req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+		rr := httptest.NewRecorder()
+		h.HandleGetSettings(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rr.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		h := testSettingsHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/admin/settings", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleGetSettings(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+}
+
+func TestSettings_HandlePatchSettings_Gaps(t *testing.T) {
+	h := testSettingsHandler(t)
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandlePatchSettings(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", rr.Code)
+		}
+	})
+
+	t.Run("no auth header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/admin/settings", nil)
+		rr := httptest.NewRecorder()
+		h.HandlePatchSettings(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rr.Code)
+		}
+	})
+}

--- a/handler/settings_patch_test.go
+++ b/handler/settings_patch_test.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSettings_HandlePatchSettings_More(t *testing.T) {
+	h := testSettingsHandler(t)
+
+	t.Run("invalid JSON body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/admin/settings", bytes.NewBufferString("not json"))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandlePatchSettings(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for invalid JSON, got %d", rr.Code)
+		}
+	})
+}

--- a/handler/settings_reload_test.go
+++ b/handler/settings_reload_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"icinga-webhook-bridge/config"
+	"icinga-webhook-bridge/configstore"
+)
+
+func TestSettings_reload(t *testing.T) {
+	t.Run("nil OnReload returns immediately", func(t *testing.T) {
+		h := testSettingsHandler(t)
+		// OnReload is nil by default, reload should not panic
+		h.reload()
+	})
+
+	t.Run("OnReload is called with config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store, _ := configstore.New(filepath.Join(tmpDir, "config.json"), "test-key")
+		store.Update(configstore.StoredConfig{
+			Icinga2Host: "http://icinga.example.com",
+			Targets: []configstore.TargetStore{
+				{ID: "t1", HostName: "host1", APIKeys: []string{"key1"}},
+			},
+		})
+
+		called := false
+		h := &SettingsHandler{
+			Store: store,
+			User:  "admin",
+			Pass:  "secret",
+			OnReload: func(cfg *config.Config) {
+				called = true
+				if cfg.Icinga2Host != "http://icinga.example.com" {
+					t.Errorf("unexpected host: %s", cfg.Icinga2Host)
+				}
+				if len(cfg.Targets) != 1 {
+					t.Errorf("expected 1 target, got %d", len(cfg.Targets))
+				}
+			},
+		}
+
+		h.reload()
+		if !called {
+			t.Error("expected OnReload to be called")
+		}
+	})
+
+	t.Run("check auth with reload configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		store, _ := configstore.New(filepath.Join(tmpDir, "config.json"), "test-key")
+		store.Update(configstore.StoredConfig{})
+
+		h := &SettingsHandler{
+			Store: store,
+			User:  "admin",
+			Pass:  "secret",
+			OnReload: func(cfg *config.Config) {
+				// no-op
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/admin/settings", nil)
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandleGetSettings(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+	})
+}

--- a/handler/targets_gap_test.go
+++ b/handler/targets_gap_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"testing"
+
+	"icinga-webhook-bridge/config"
+)
+
+func TestResolveScopedHosts(t *testing.T) {
+	targets := map[string]config.TargetConfig{
+		"a": {ID: "a", HostName: "alpha"},
+		"b": {ID: "b", HostName: "beta"},
+	}
+
+	t.Run("specific host found", func(t *testing.T) {
+		result, err := resolveScopedHosts(targets, "alpha")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 || result[0].HostName != "alpha" {
+			t.Errorf("expected [alpha], got %v", result)
+		}
+	})
+
+	t.Run("specific host not found", func(t *testing.T) {
+		_, err := resolveScopedHosts(targets, "nonexistent")
+		if err == nil {
+			t.Error("expected error for unknown host")
+		}
+	})
+
+	t.Run("empty host returns all sorted", func(t *testing.T) {
+		result, err := resolveScopedHosts(targets, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("expected 2 results, got %d", len(result))
+		}
+		if result[0].HostName != "alpha" || result[1].HostName != "beta" {
+			t.Errorf("expected sorted [alpha, beta], got %v", result)
+		}
+	})
+}
+
+func TestResolveSingleHost(t *testing.T) {
+	targets := map[string]config.TargetConfig{
+		"a": {ID: "a", HostName: "alpha"},
+		"b": {ID: "b", HostName: "beta"},
+	}
+
+	t.Run("specific host found", func(t *testing.T) {
+		result, err := resolveSingleHost(targets, "alpha")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.HostName != "alpha" {
+			t.Errorf("expected alpha, got %s", result.HostName)
+		}
+	})
+
+	t.Run("specific host not found", func(t *testing.T) {
+		_, err := resolveSingleHost(targets, "nonexistent")
+		if err == nil {
+			t.Error("expected error for unknown host")
+		}
+	})
+
+	t.Run("multiple targets but no host specified", func(t *testing.T) {
+		_, err := resolveSingleHost(targets, "")
+		if err == nil {
+			t.Error("expected error: host query parameter required for multiple targets")
+		}
+	})
+
+	t.Run("single target no host ok", func(t *testing.T) {
+		single := map[string]config.TargetConfig{
+			"a": {ID: "a", HostName: "only"},
+		}
+		result, err := resolveSingleHost(single, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.HostName != "only" {
+			t.Errorf("expected only, got %s", result.HostName)
+		}
+	})
+}

--- a/handler/test_mode_extra_test.go
+++ b/handler/test_mode_extra_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"icinga-webhook-bridge/config"
+	"icinga-webhook-bridge/models"
+)
+
+func TestHandleTestMode_UnknownAction(t *testing.T) {
+	h := testWebhookHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results":[{"code":200}]}`))
+	})
+
+	result := h.handleTestMode("req-1", "grafana", config.TargetConfig{HostName: "host-a"}, models.GrafanaAlert{
+		Labels: map[string]string{"test_action": "invalid_action", "alertname": "svc-test"},
+	}, "127.0.0.1")
+
+	if result["status"] != "error" {
+		t.Errorf("expected error status, got %v", result["status"])
+	}
+	if result["service"] == "" {
+		t.Error("expected service name in result")
+	}
+}
+
+func TestHandleTestCreate_AlreadyExists(t *testing.T) {
+	h := testWebhookHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results":[{"code":200}]}`))
+	})
+
+	// Pre-register service in cache
+	h.Cache.Register("host-a", "test-service")
+
+	result := h.handleTestCreate("req-1", "grafana", config.TargetConfig{HostName: "host-a"},
+		"test-service", models.GrafanaAlert{}, "127.0.0.1")
+
+	if result["status"] != "already_exists" {
+		t.Errorf("expected already_exists, got %v", result["status"])
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2b: Added handler tests to reach 70% coverage target. httputil already at 80%.

| Package | Before | After | Target |
|---------|--------|-------|--------|
| `handler` | 57.7% | **70.3%** | 70% |
| `httputil` | 80.0% | 80.0% | 70% |

## Changes

8 new test files added to `handler/`:
- **admin_gap_test.go** — HandleClearHistory, HandleDebugToggle, HandleDeleteService, HandleBulkDelete edge cases
- **targets_gap_test.go** — resolveScopedHosts, resolveSingleHost
- **settings_gap_test.go** — checkAuth branches (RBAC, metrics, wrong password)
- **settings_patch_test.go** — invalid JSON body
- **settings_reload_test.go** — OnReload callback
- **dashboard_status_test.go** — toDashboardAlert, isAdmin, buildSourceIPLists (pure functions)
- **dashboard_minimal_test.go** — ServeHTTP (405, 200, 401 for admin)
- **test_mode_extra_test.go** — handleTestMode unknown action, handleTestCreate already-exists

Dashboard ServeHTTP now partially covered (method check, basic render, admin auth gate). Full template rendering not tested (requires Icinga2 API mock).

## Manual Verification

- [x] `go test ./handler/ -cover` — 70.3%, all pass
- [x] `go vet ./...` — clean

## References

Phase 2b of PLAN.md.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)