### PR TITLE
chore(phase-5): developer experience — pre-commit, devcontainer, editorconfig

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "IcingaAlertForge",
+  "image": "mcr.microsoft.com/devcontainers/go:1.24",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "redhat.vscode-yaml",
+        "davidanson.vscode-markdownlint"
+      ],
+      "settings": {
+        "go.toolsManagement.autoUpdate": true,
+        "go.lintTool": "golangci-lint",
+        "go.lintOnSave": "package",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": "explicit"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "go mod download && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest",
+  "remoteUser": "vscode"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: detect-private-key
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      - id: go-vet
+        args: [./...]
+
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.2.0
+    hooks:
+      - id: golangci-lint-full
+        args: [--timeout=5m]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ cp .env.example .env  # edit with your Icinga2 credentials
 ### Quick Start
 
 ```bash
+make setup-dev  # install pre-commit hooks + dev tools
 make build      # compile the binary
 make test       # run unit tests
 make lint       # run golangci-lint
@@ -61,6 +62,18 @@ make vulncheck        # govulncheck
 ```
 
 Configuration is in `.golangci.yml`. Do not weaken lint rules — fix the code.
+
+## Pre-commit Hooks
+
+Pre-commit hooks run automatically before each commit:
+
+```bash
+make setup-dev     # installs pre-commit, hooks, and golangci-lint
+```
+
+Hooks: go-fmt, go-imports, go-vet, golangci-lint, gitleaks, trailing-whitespace, end-of-file-fixer, check-yaml, check-merge-conflict, detect-private-key.
+
+Skip hooks in an emergency: `git commit --no-verify`. Do not skip in normal workflow.
 
 ## Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,13 @@ outdated:
 	@echo ""
 	@echo "Run 'go get -u ./...' to update, then 'go mod tidy'."
 
+## setup-dev — install development dependencies (pre-commit, golangci-lint)
+setup-dev:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Installing pre-commit..."; brew install pre-commit || pip install pre-commit; }
+	pre-commit install
+	@command -v golangci-lint >/dev/null 2>&1 || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@echo "Development environment ready."
+
 ## clean — remove binary
 clean:
 	rm -f $(BINARY) webhook-bridge coverage.out merge-report.md


### PR DESCRIPTION
## Summary

Phase 5: Catch errors before they reach CI with pre-commit hooks, and enable one-click dev setup.

## Changes

| File | Purpose |
|------|---------|
| `.pre-commit-config.yaml` | 10 hooks: go-fmt, go-imports, go-vet, golangci-lint, gitleaks, etc. |
| `.devcontainer/devcontainer.json` | VS Code / Codespaces: Go 1.24 + Docker + Node |
| `.editorconfig` | Consistent whitespace: tabs for Go, spaces for YAML/JSON/MD |
| `CONTRIBUTING.md` | Added pre-commit install instructions |
| `Makefile` | Added `setup-dev` target |

## Manual Verification

- [x] `.editorconfig` validates
- [x] `.devcontainer/devcontainer.json` validates (JSON)
- [x] `make ci` — all checks pass

## Quick Start

```bash
make setup-dev  # one command to install everything
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)