### PR TITLE
fix(testenv): repair broken Icinga2 API feature symlink

### DIFF
--- a/testenv/icinga2/Dockerfile
+++ b/testenv/icinga2/Dockerfile
@@ -20,7 +20,10 @@ COPY conf.d/ido-mysql.conf     /data/etc/icinga2/features-available/ido-mysql.co
 # Enable IDO MySQL feature and the API feature (via symlink)
 RUN mkdir -p /data/etc/icinga2/features-enabled && \
     ln -sf ../features-available/ido-mysql.conf \
-           /data/etc/icinga2/features-enabled/ido-mysql.conf
+           /data/etc/icinga2/features-enabled/ido-mysql.conf && \
+    rm -f /data/etc/icinga2/features-enabled/api.conf && \
+    ln -sf ../features-available/api.conf \
+           /data/etc/icinga2/features-enabled/api.conf
 
 # Generate TLS certs into /data/var/lib/icinga2/certs/
 RUN mkdir -p /data/var/lib/icinga2/certs /data/var/lib/icinga2/ca && \


### PR DESCRIPTION
The upstream icinga/icinga2 base image creates an api.conf symlink pointing to /data-init/etc/icinga2/features-available/api.conf which no longer exists in newer image versions. This prevents the Icinga2 REST API from starting (no ApiListener), which blocks the webhook-bridge and Icinga Web 2 from connecting.

Fix: remove the broken symlink and recreate it with the correct relative path to ../features-available/api.conf.