### PR TITLE
fix(testenv): generate Icinga2 TLS certs at runtime, remove deprecated SSL attrs

### DIFF
--- a/testenv/icinga2/Dockerfile
+++ b/testenv/icinga2/Dockerfile
@@ -17,33 +17,16 @@ COPY conf.d/users.conf         /data/etc/icinga2/conf.d/users.conf
 COPY conf.d/notifications.conf /data/etc/icinga2/conf.d/notifications.conf
 COPY conf.d/ido-mysql.conf     /data/etc/icinga2/features-available/ido-mysql.conf
 
-# Enable IDO MySQL feature and the API feature (via symlink)
+# Enable IDO MySQL feature. Remove stale api.conf symlink (ApiListener is
+# defined in conf.d/api.conf instead — the base-image symlink points to a
+# non-existent /data-init path).
 RUN mkdir -p /data/etc/icinga2/features-enabled && \
     ln -sf ../features-available/ido-mysql.conf \
            /data/etc/icinga2/features-enabled/ido-mysql.conf && \
-    rm -f /data/etc/icinga2/features-enabled/api.conf && \
-    ln -sf ../features-available/api.conf \
-           /data/etc/icinga2/features-enabled/api.conf
+    rm -f /data/etc/icinga2/features-enabled/api.conf
 
-# Generate TLS certs into /data/var/lib/icinga2/certs/
-RUN mkdir -p /data/var/lib/icinga2/certs /data/var/lib/icinga2/ca && \
-    openssl genrsa -out /data/var/lib/icinga2/ca/ca.key 4096 && \
-    openssl req -x509 -new -nodes -key /data/var/lib/icinga2/ca/ca.key \
-      -sha256 -days 3650 -out /data/var/lib/icinga2/ca/ca.crt \
-      -subj "/CN=Icinga CA" && \
-    openssl genrsa -out /data/var/lib/icinga2/certs/icinga2.key 4096 && \
-    openssl req -new -key /data/var/lib/icinga2/certs/icinga2.key \
-      -out /tmp/icinga2.csr -subj "/CN=icinga2" && \
-    openssl x509 -req -in /tmp/icinga2.csr \
-      -CA /data/var/lib/icinga2/ca/ca.crt \
-      -CAkey /data/var/lib/icinga2/ca/ca.key \
-      -CAcreateserial -out /data/var/lib/icinga2/certs/icinga2.crt \
-      -days 3650 -sha256 && \
-    cp /data/var/lib/icinga2/ca/ca.crt /data/var/lib/icinga2/certs/ca.crt && \
-    chown -R icinga:icinga /data/var/lib/icinga2/certs /data/var/lib/icinga2/ca \
-                           /data/etc/icinga2/conf.d /data/etc/icinga2/features-available \
-                           /data/etc/icinga2/features-enabled && \
-    rm -f /tmp/icinga2.csr
+# Certs are generated at container start by entrypoint-wrapper.sh because
+# /data is a VOLUME in the base image — RUN writes do not survive runtime.
 
 COPY entrypoint-wrapper.sh /entrypoint-wrapper.sh
 RUN chmod +x /entrypoint-wrapper.sh

--- a/testenv/icinga2/conf.d/api.conf
+++ b/testenv/icinga2/conf.d/api.conf
@@ -1,9 +1,5 @@
 object ApiListener "api" {
-  cert_path = "/data/var/lib/icinga2/certs/icinga2.crt"
-  key_path  = "/data/var/lib/icinga2/certs/icinga2.key"
-  ca_path   = "/data/var/lib/icinga2/certs/ca.crt"
-
-  bind_port      = 5665
-  accept_config  = true
+  bind_port = 5665
+  accept_config = true
   accept_commands = true
 }

--- a/testenv/icinga2/entrypoint-wrapper.sh
+++ b/testenv/icinga2/entrypoint-wrapper.sh
@@ -1,5 +1,29 @@
 #!/bin/sh
-# Wait for MariaDB and import IDO schema, then start icinga2 daemon.
+# Wait for MariaDB, import IDO schema, generate TLS certs, start icinga2.
+
+CERT_DIR="/data/var/lib/icinga2/certs"
+CA_DIR="/data/var/lib/icinga2/ca"
+
+# Generate TLS certs at runtime (not during build — /data is a VOLUME)
+if [ ! -f "$CERT_DIR/icinga2.crt" ] || [ ! -f "$CERT_DIR/icinga2.key" ]; then
+    echo "Generating Icinga2 TLS certificates..."
+    mkdir -p "$CERT_DIR" "$CA_DIR"
+    openssl genrsa -out "$CA_DIR/ca.key" 4096
+    openssl req -x509 -new -nodes -key "$CA_DIR/ca.key" \
+        -sha256 -days 3650 -out "$CA_DIR/ca.crt" \
+        -subj "/CN=Icinga CA"
+    openssl genrsa -out "$CERT_DIR/icinga2.key" 4096
+    openssl req -new -key "$CERT_DIR/icinga2.key" \
+        -out /tmp/icinga2.csr -subj "/CN=icinga2"
+    openssl x509 -req -in /tmp/icinga2.csr \
+        -CA "$CA_DIR/ca.crt" -CAkey "$CA_DIR/ca.key" \
+        -CAcreateserial -out "$CERT_DIR/icinga2.crt" \
+        -days 3650 -sha256
+    cp "$CA_DIR/ca.crt" "$CERT_DIR/ca.crt"
+    chown -R icinga:icinga "$CERT_DIR" "$CA_DIR"
+    rm -f /tmp/icinga2.csr
+    echo "TLS certificates generated."
+fi
 
 MYSQL_OPTS="-h mariadb -u icinga2_ido -picinga2_idopass --ssl=FALSE icinga2_ido"
 


### PR DESCRIPTION
The icinga/icinga2 base image declares /data as a VOLUME, so TLS certificates generated during docker build are silently discarded. This caused the Icinga2 container to fail on startup with cert file not found errors.

Moved cert generation to entrypoint-wrapper.sh which runs at container start (with idempotency check). Also removed deprecated cert_path/key_path/ca_path from api.conf and the redundant api.conf features-enabled symlink.