### PR TITLE
fix: preserve MetricsEnabled when loading config from dashboard store

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,9 @@ func main() {
 			storedCfg.AuditLogEnabled = cfg.AuditLogEnabled
 			storedCfg.AuditLogFile = cfg.AuditLogFile
 			storedCfg.AuditLogFormat = cfg.AuditLogFormat
+			// Metrics + observability (env-only, never in JSON store)
+			storedCfg.MetricsEnabled = cfg.MetricsEnabled
+			storedCfg.MetricsToken = cfg.MetricsToken
 			cfg = storedCfg
 			slog.Info("Configuration loaded from dashboard store", "path", cfg.ConfigFilePath)
 		} else {


### PR DESCRIPTION
When CONFIG_IN_DASHBOARD=true, the JSON store config overrides env config. MetricsEnabled and MetricsToken are env-only fields (not stored in the JSON config), so they were reset to zero values — disabling /metrics and breaking Prometheus scraping.

Fix: explicitly copy these fields from env config to stored config, matching the existing pattern for RetryQueueEnabled, HealthCheckEnabled, AuditLogEnabled, etc.