### PR TITLE
docs: warn about missing generic-host and generic-service templates in Icinga2

### DIFF
--- a/docs/guides/icinga-integration.md
+++ b/docs/guides/icinga-integration.md
@@ -212,6 +212,12 @@ Structured logs include:
 
 That makes it possible to see which key sent an alert and which host in Icinga was touched.
 
+### "Import references unknown template" Error
+
+If auto-creation fails with HTTP 500 and `Import references unknown template`, your Icinga2 environment is missing the `generic-host` and/or `generic-service` templates. This is common in Icinga Director or minimal installations. See [Troubleshooting — Import references unknown template](../troubleshooting.md#import-references-unknown-template-http-500) for the fix.
+
+---
+
 ## Next Step
 
 Continue with [Beauty Panel](beauty-panel.md) or [Test Environment](test-environment.md).

--- a/docs/guides/quick-setup.md
+++ b/docs/guides/quick-setup.md
@@ -237,5 +237,6 @@ Grafana/Prometheus → webhook POST → Bridge → Icinga2 API
 | 401 Unauthorized | Klucz API nie pasuje do żadnego targetu |
 | 502 Bad Gateway | Icinga2 nieodpowiada — sprawdź `ICINGA2_HOST` i credentials |
 | "Host does not exist" | Ustaw `ICINGA2_HOST_AUTO_CREATE=true` albo stwórz hosta ręcznie |
+| "Import references unknown template" (500) | Brakuje szablonów `generic-host`/`generic-service` w Icinga2 — dodaj je do `/etc/icinga2/conf.d/templates.conf` albo wyłącz auto-kreację przez `ICINGA2_HOST_AUTO_CREATE=false`. Szczegóły: [Troubleshooting](../troubleshooting.md#import-references-unknown-template-http-500) |
 | Panel nie pokazuje Settings | `CONFIG_IN_DASHBOARD=true` nie jest ustawione |
 | Zmiany w panelu nie działają | Sprawdź logi — hot-reload może failować przy błędnych danych |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,6 +44,37 @@ Fix:
 - Use the `ICINGA2_FORCE=true` flag to override ownership checks
 - Or set the service's `vars.managed_by` to `IcingaAlertingForge` in Icinga2
 
+### "Import references unknown template" (HTTP 500)
+
+When the bridge tries to auto-create a host or service, Icinga2 may respond with HTTP 500 and the error message `Import references unknown template`. This happens because the bridge hardcodes the `generic-host` and `generic-service` templates, which are missing in some Icinga2 environments — especially those managed by Icinga Director or minimal installations.
+
+**Solution A: Add the missing templates**
+
+Create `/etc/icinga2/conf.d/templates.conf` and reload Icinga2:
+
+```icinga2
+template Host "generic-host" {
+  max_check_attempts = 3
+  check_interval = 1m
+  retry_interval = 30s
+  check_command = "hostalive"
+}
+
+template Service "generic-service" {
+  max_check_attempts = 5
+  check_interval = 1m
+  retry_interval = 30s
+}
+```
+
+```bash
+icinga2 daemon -C && systemctl reload icinga2
+```
+
+**Solution B: Disable auto-creation**
+
+Set `ICINGA2_HOST_AUTO_CREATE=false` and manually create the dummy host in Icinga2 with the required custom variables (`vars.managed_by`, `vars.iaf_managed`).
+
 ### Icinga2 connection refused
 
 The bridge cannot reach the Icinga2 API.

--- a/wiki/Icinga.md
+++ b/wiki/Icinga.md
@@ -80,3 +80,30 @@ The central client for interacting with Icinga2. It is thread-safe and supports 
     - `skip`: Log a warning and do nothing.
     - `warn`: Proceed but log a warning.
     - `fail`: Stop and return an error.
+
+---
+
+## Template Requirements
+
+The API client hardcodes `generic-host` and `generic-service` templates when creating objects via `CreateHost` and `CreateService`. These templates must exist in your Icinga2 configuration, otherwise the API returns HTTP 500 with `Import references unknown template`.
+
+Environments managed by Icinga Director or minimal Icinga2 installations often lack these templates. Add them to `/etc/icinga2/conf.d/templates.conf`:
+
+```icinga2
+template Host "generic-host" {
+  max_check_attempts = 3
+  check_interval = 1m
+  retry_interval = 30s
+  check_command = "hostalive"
+}
+
+template Service "generic-service" {
+  max_check_attempts = 5
+  check_interval = 1m
+  retry_interval = 30s
+}
+```
+
+After adding the templates, run `icinga2 daemon -C && systemctl reload icinga2`.
+
+Alternatively, disable auto-creation by setting `ICINGA2_HOST_AUTO_CREATE=false` and create hosts manually.


### PR DESCRIPTION
When the bridge tries to auto-create hosts or services using the hardcoded `generic-host` and `generic-service` templates, Icinga2 returns HTTP 500 "Import references unknown template" if those templates don't exist. This is common in Icinga Director or minimal Icinga2 installations.

Added the warning and fix to:
- `docs/troubleshooting.md` — new dedicated section
- `docs/guides/icinga-integration.md` — warning box in auto-creation section
- `docs/guides/quick-setup.md` — entry in troubleshooting table
- `wiki/Icinga.md` — Template Requirements section

🤖 Generated with [Claude Code](https://claude.com/claude-code)