### PR TITLE
fix: use single quotes for regex patterns in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,13 +39,13 @@ changelog:
   sort: asc
   groups:
     - title: Breaking Changes
-      regexp: "^.*!?:.*"
+      regexp: '^.*!?:.*'
       order: 0
     - title: Features
-      regexp: "^feat(\(.*\))?:.*"
+      regexp: '^feat(\(.*\))?:.*'
       order: 1
     - title: Fixes
-      regexp: "^fix(\(.*\))?:.*"
+      regexp: '^fix(\(.*\))?:.*'
       order: 2
     - title: Others
       order: 999


### PR DESCRIPTION
YAML double-quoted strings interpret backslash escapes, so `\(` in regex patterns like `^feat(\(.*\))?:.*` causes:
```
error=yaml: line 45: found unknown escape character
```

Switching to single-quoted strings fixes this — single quotes treat all characters literally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)