### PR TITLE
feat: add dashboard-mode docker-compose for manual panel testing

### DIFF
--- a/testenv/.env.dashboard
+++ b/testenv/.env.dashboard
@@ -1,0 +1,41 @@
+# ── Dashboard-Only Test Environment ──────────────────────────
+# Użyj: docker compose -f docker-compose.dashboard.yml up -d
+#
+# Ten tryb startuje bridge BEZ żadnych predefiniowanych targetów.
+# Wszystko konfigurujesz ręcznie przez panel:
+#   http://localhost:9081/status/beauty?admin=1
+#
+# Wymaga działającego Icinga2 (np. z głównego testenv):
+#   docker compose up -d icinga2 mariadb
+
+SERVER_PORT=8080
+SERVER_HOST=0.0.0.0
+
+# ── Icinga2 connection (points to testenv Icinga2) ──────────
+ICINGA2_HOST=https://icinga2:5665
+ICINGA2_USER=apiuser
+ICINGA2_PASS=apipassword
+ICINGA2_TLS_SKIP_VERIFY=true
+ICINGA2_HOST_AUTO_CREATE=true
+
+# ── Admin credentials ──────────────────────────────────────
+ADMIN_USER=admin
+ADMIN_PASS=admin123
+
+# ── Dashboard Mode — kluczowe! ─────────────────────────────
+# Bez tego bridge wymaga IAF_TARGET_* albo ICINGA2_HOST_NAME w .env
+CONFIG_IN_DASHBOARD=true
+
+# ── Storage ────────────────────────────────────────────────
+HISTORY_FILE=/var/log/webhook-bridge/history.jsonl
+HISTORY_MAX_ENTRIES=5000
+CACHE_TTL_MINUTES=30
+
+# ── Logging ────────────────────────────────────────────────
+LOG_LEVEL=debug
+LOG_FORMAT=text
+
+# ── Rate limits (hojne dla testów) ─────────────────────────
+RATELIMIT_MUTATE_MAX=20
+RATELIMIT_STATUS_MAX=50
+RATELIMIT_MAX_QUEUE=2000

--- a/testenv/docker-compose.dashboard.yml
+++ b/testenv/docker-compose.dashboard.yml
@@ -1,0 +1,32 @@
+networks:
+  monitoring:
+    external: true
+    name: testenv_monitoring
+
+volumes:
+  dashboard_logs:
+
+services:
+  # ── Webhook Bridge (dashboard mode — zero pre-config) ──────────
+  webhook-bridge:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${IAF_VERSION:-dev}
+    container_name: testenv-dashboard-bridge
+    hostname: dashboard-bridge
+    networks:
+      - monitoring
+    ports:
+      - "9081:8080"
+    env_file:
+      - .env.dashboard
+    volumes:
+      - dashboard_logs:/var/log/webhook-bridge
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s


### PR DESCRIPTION
## Summary
Adds a lightweight, separate docker-compose for testing dashboard-mode configuration:

- `testenv/docker-compose.dashboard.yml` — starts only the bridge, connects to existing testenv Icinga2
- `testenv/.env.dashboard` — minimal env: just Icinga2 connection + admin creds + `CONFIG_IN_DASHBOARD=true`
- **Zero pre-configured targets** — everything created manually via the beauty panel

## Usage
```bash
# Start Icinga2 + DB first (from main compose)
docker compose up -d icinga2 mariadb

# Start dashboard bridge (separate container, port 9081)
docker compose -f docker-compose.dashboard.yml up -d --build

# Open: http://localhost:9081/status/beauty?admin=1
# Login: admin / admin123
```

## Test verification
- All 15 Go test packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)