### PR TITLE
fix: register /status/beauty/stats route explicitly for Go 1.25 mux

### DIFF
--- a/main.go
+++ b/main.go
@@ -449,6 +449,7 @@ func main() {
 		w.WriteHeader(http.StatusUnauthorized)
 		fmt.Fprint(w, `<html><head><meta http-equiv="refresh" content="1;url=/status/beauty"></head><body>Logged out. Redirecting...</body></html>`)
 	})
+	mux.HandleFunc("/status/beauty/stats", dashboardHandler.HandleStats)
 	mux.HandleFunc("/status/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		statusHandler.ServeHTTP(w, r)
 	}))

--- a/testenv/docker-compose.dashboard.yml
+++ b/testenv/docker-compose.dashboard.yml
@@ -1,3 +1,4 @@
+name: dashboard
 networks:
   monitoring:
     external: true
@@ -8,7 +9,7 @@ volumes:
 
 services:
   # ── Webhook Bridge (dashboard mode — zero pre-config) ──────────
-  webhook-bridge:
+  dashboard-bridge:
     build:
       context: ..
       dockerfile: Dockerfile


### PR DESCRIPTION
## Problem
Go 1.22+ default mux uses exact-match for patterns without trailing slash. `/status/beauty` matched only the exact path, so `/status/beauty/stats` fell through to the `/status/` subtree handler. This broke live stats in the beauty panel.

## Fix
Register `/status/beauty/stats` explicitly. Also fixes dashboard compose service naming.

## Verified
- Both testenv bridges running, stats return HTTP 200 without auth
- All 15 Go test packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)