### PR TITLE
fix: periodic cache re-sync so green Icinga2 services don't expire from dashboard

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,6 +147,7 @@ func main() {
 	defer mainCancel()
 	historyLogger.StartMaintenance(mainCtx)
 	serviceCache.StartMaintenance(mainCtx, time.Minute)
+	startCacheResync(mainCtx, apiClient, serviceCache, cfg.Targets, time.Duration(cfg.CacheTTLMinutes)*time.Minute)
 
 	// ── Metrics Collector ────────────────────────────────────────────
 	metricsCollector := metrics.NewCollector()
@@ -697,6 +698,43 @@ func restoreManagedServicesFromIcinga(apiClient *icinga.APIClient, serviceCache 
 			"sample", legacySamples,
 			"expected_managed_by", icinga.ManagedByIAF)
 	}
+}
+
+// startCacheResync periodically re-registers managed services from Icinga2 so
+// that healthy (green) services which never emit a webhook event do not expire
+// from the cache and disappear from the dashboard. Each pass refreshes the
+// entry's CreatedAt, keeping live services inside the TTL window while still
+// letting genuinely deleted services age out.
+//
+// The interval is derived from the TTL (a quarter of it, with a one-minute
+// floor) so that several consecutive resync failures can occur before an entry
+// is at risk of expiring.
+func startCacheResync(ctx context.Context, apiClient *icinga.APIClient, serviceCache *cache.ServiceCache, targets map[string]config.TargetConfig, ttl time.Duration) {
+	interval := ttl / 4
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+	slog.Info("Cache resync enabled", "interval", interval, "ttl", ttl)
+	startCacheResyncEvery(ctx, apiClient, serviceCache, targets, interval)
+}
+
+// startCacheResyncEvery runs a resync pass over all targets on the given
+// interval until ctx is cancelled.
+func startCacheResyncEvery(ctx context.Context, apiClient *icinga.APIClient, serviceCache *cache.ServiceCache, targets map[string]config.TargetConfig, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for _, target := range sortedTargets(targets) {
+					restoreManagedServicesFromIcinga(apiClient, serviceCache, target.HostName)
+				}
+			}
+		}
+	}()
 }
 
 func ensureConfiguredHosts(apiClient *icinga.APIClient, targets map[string]config.TargetConfig, autoCreate bool) error {

--- a/main.go
+++ b/main.go
@@ -719,7 +719,7 @@ func startCacheResync(ctx context.Context, apiClient *icinga.APIClient, serviceC
 }
 
 // startCacheResyncEvery runs a resync pass over all targets on the given
-// interval until ctx is cancelled.
+// interval until ctx is canceled.
 func startCacheResyncEvery(ctx context.Context, apiClient *icinga.APIClient, serviceCache *cache.ServiceCache, targets map[string]config.TargetConfig, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	go func() {

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"icinga-webhook-bridge/cache"
+	"icinga-webhook-bridge/config"
 	"icinga-webhook-bridge/icinga"
 )
 
@@ -49,5 +52,55 @@ func TestRestoreManagedServicesFromIcinga_RestoresManagedAndLegacyOnly(t *testin
 	}
 	if len(serviceCache.All()) != 2 {
 		t.Fatalf("expected exactly 2 cached services, got %d", len(serviceCache.All()))
+	}
+}
+
+func TestStartCacheResync_PeriodicallyReRegistersManagedServices(t *testing.T) {
+	calls := make(chan struct{}, 16)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"results": [
+				{"attrs": {"name": "IAF Device 01", "vars": {"managed_by": "IcingaAlertingForge"}}}
+			]
+		}`))
+		select {
+		case calls <- struct{}{}:
+		default:
+		}
+	}))
+	defer server.Close()
+
+	apiClient := &icinga.APIClient{
+		BaseURL:    server.URL,
+		User:       "test",
+		Pass:       "test",
+		HTTPClient: server.Client(),
+	}
+	serviceCache := cache.NewServiceCache(10)
+	targets := map[string]config.TargetConfig{
+		"default": {HostName: "test-host"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Drive the loop with an explicit tiny interval so the test does not depend on
+	// wall-clock timing; assert on observed periodic passes instead.
+	startCacheResyncEvery(ctx, apiClient, serviceCache, targets, 5*time.Millisecond)
+
+	// Expect at least two independent resync passes.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-calls:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected periodic resync pass %d, but none occurred", i+1)
+		}
+	}
+
+	cancel()
+
+	if !serviceCache.Exists("test-host", "IAF Device 01") {
+		t.Fatal("expected managed service to be present in cache after resync")
 	}
 }


### PR DESCRIPTION
## Problem

The beauty dashboard renders its service list from the TTL cache (`handler/dashboard.go` → `h.Cache.AllEntries()`). Cache entries expire based on **`CreatedAt` (registration time), not last-seen** (`cache/services.go`). The cache is only refreshed on:

1. Startup — `restoreManagedServicesFromIcinga`
2. An incoming webhook/event for that service

A healthy (green) service that emits no alerts/events therefore never gets its `CreatedAt` refreshed. After `CACHE_TTL_MINUTES` (default 60) it silently disappears from the dashboard, even though it is still green in Icinga2.

## Fix

Add `startCacheResync`: a goroutine that periodically re-registers managed services from Icinga2, refreshing `CreatedAt` and keeping live services inside the TTL window. The interval is derived from the TTL (`TTL/4`, floored at 1 min) so several consecutive resync failures can occur before an entry risks expiry. Genuinely deleted services still age out normally, so the TTL continues to bound memory.

## Test

`TestStartCacheResync_PeriodicallyReRegistersManagedServices` drives the loop with an explicit short interval and asserts the resync runs repeatedly and keeps the service in cache.

- `go build ./...`, `go vet ./...` clean
- Relevant tests pass with `-race`
- Note: the pre-existing `e2e/TestDashboard_Renders` failure ("missing stat-firing") is unrelated — it also fails on a clean tree without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)