### PR TITLE
feat: per-IP webhook ingress rate limit (flood protection)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,10 @@ type Config struct {
 	// Cache
 	CacheTTLMinutes int
 
+	// Webhook ingress flood protection (per source IP). 0 = disabled.
+	WebhookRateLimitPerSec int
+	WebhookRateLimitBurst  int
+
 	// Logging
 	LogLevel  string
 	LogFormat string
@@ -202,6 +206,15 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	if cfg.CacheTTLMinutes, err = optInt("CACHE_TTL_MINUTES", 60); err != nil {
+		return nil, err
+	}
+
+	// Per-IP webhook flood protection. Generous defaults that only block actual
+	// floods; set WEBHOOK_RATELIMIT_PER_SEC=0 to disable.
+	if cfg.WebhookRateLimitPerSec, err = optInt("WEBHOOK_RATELIMIT_PER_SEC", 50); err != nil {
+		return nil, err
+	}
+	if cfg.WebhookRateLimitBurst, err = optInt("WEBHOOK_RATELIMIT_BURST", 100); err != nil {
 		return nil, err
 	}
 

--- a/handler/webhook.go
+++ b/handler/webhook.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +25,7 @@ import (
 	"icinga-webhook-bridge/metrics"
 	"icinga-webhook-bridge/models"
 	"icinga-webhook-bridge/queue"
+	"icinga-webhook-bridge/ratelimit"
 )
 
 // WebhookHandler is the main HTTP handler for incoming Grafana webhooks.
@@ -34,6 +38,7 @@ type WebhookHandler struct {
 	History    *history.Logger
 	Targets    map[string]config.TargetConfig
 	Limiter    *icinga.RateLimiter
+	Ingress    *ratelimit.Limiter // per-IP ingress flood protection (nil = disabled)
 	Metrics    *metrics.Collector
 	PerKey     *metrics.PerKeyCollector
 	SSE        *SSEBroker
@@ -42,10 +47,34 @@ type WebhookHandler struct {
 	Audit      *audit.Logger
 }
 
+// clientIP extracts the client IP (without port) from RemoteAddr for rate-limit
+// keying. Falls back to the raw RemoteAddr if it has no port.
+func clientIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}
+
 // ServeHTTP handles POST /webhook requests from Grafana.
 func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		httputil.WriteJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	// ── Ingress rate limit (per source IP) ──────────────────────────
+	// Enforced before authentication so floods of invalid keys are also
+	// throttled at the source, protecting CPU/IO and Icinga2 downstream.
+	if allowed, retryAfter := h.Ingress.Allow(clientIP(r.RemoteAddr)); !allowed {
+		retrySec := int(math.Ceil(retryAfter.Seconds()))
+		if retrySec < 1 {
+			retrySec = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(retrySec))
+		slog.Warn("Webhook rate limit exceeded", "remote_addr", r.RemoteAddr, "retry_after_s", retrySec)
+		httputil.WriteJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		return
 	}
 

--- a/handler/webhook_test.go
+++ b/handler/webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"icinga-webhook-bridge/config"
 	"icinga-webhook-bridge/history"
 	"icinga-webhook-bridge/icinga"
+	"icinga-webhook-bridge/ratelimit"
 )
 
 // testWebhookHandler creates a WebhookHandler wired to a mock Icinga2 API server.
@@ -61,6 +62,37 @@ func testWebhookHandler(t *testing.T, icingaHandler http.HandlerFunc) *WebhookHa
 				HostName: "team-b-host",
 			},
 		},
+	}
+}
+
+func TestWebhook_RateLimit_Returns429AfterBurst(t *testing.T) {
+	h := testWebhookHandler(t, func(w http.ResponseWriter, r *http.Request) {})
+	h.Ingress = ratelimit.New(1, 2) // 1 req/s, burst of 2
+
+	send := func(remoteAddr string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewBufferString(`{}`))
+		req.Header.Set("X-API-Key", "valid-key")
+		req.RemoteAddr = remoteAddr
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// First two requests consume the burst and pass the rate gate.
+	send("203.0.113.7:5555")
+	send("203.0.113.7:5555")
+
+	rr := send("203.0.113.7:5555")
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 after burst exhausted, got %d", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header on 429 response")
+	}
+
+	// A different source IP has an independent bucket and is not throttled.
+	if rr := send("198.51.100.9:4444"); rr.Code == http.StatusTooManyRequests {
+		t.Error("a different source IP should not be rate limited")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"icinga-webhook-bridge/icinga"
 	"icinga-webhook-bridge/metrics"
 	"icinga-webhook-bridge/queue"
+	"icinga-webhook-bridge/ratelimit"
 	"icinga-webhook-bridge/rbac"
 )
 
@@ -93,6 +94,9 @@ func main() {
 			// Metrics + observability (env-only, never in JSON store)
 			storedCfg.MetricsEnabled = cfg.MetricsEnabled
 			storedCfg.MetricsToken = cfg.MetricsToken
+			// Webhook flood protection (env-only security control)
+			storedCfg.WebhookRateLimitPerSec = cfg.WebhookRateLimitPerSec
+			storedCfg.WebhookRateLimitBurst = cfg.WebhookRateLimitBurst
 			cfg = storedCfg
 			slog.Info("Configuration loaded from dashboard store", "path", cfg.ConfigFilePath)
 		} else {
@@ -148,6 +152,16 @@ func main() {
 	historyLogger.StartMaintenance(mainCtx)
 	serviceCache.StartMaintenance(mainCtx, time.Minute)
 	startCacheResync(mainCtx, apiClient, serviceCache, cfg.Targets, time.Duration(cfg.CacheTTLMinutes)*time.Minute)
+
+	// ── Webhook ingress flood protection (per source IP) ────────────
+	ingressLimiter := ratelimit.New(float64(cfg.WebhookRateLimitPerSec), cfg.WebhookRateLimitBurst)
+	if ingressLimiter != nil {
+		ingressLimiter.StartEviction(mainCtx, time.Minute)
+		slog.Info("Webhook ingress rate limit enabled",
+			"per_sec", cfg.WebhookRateLimitPerSec, "burst", cfg.WebhookRateLimitBurst)
+	} else {
+		slog.Warn("Webhook ingress rate limit disabled")
+	}
 
 	// ── Metrics Collector ────────────────────────────────────────────
 	metricsCollector := metrics.NewCollector()
@@ -278,6 +292,7 @@ func main() {
 		History:    historyLogger,
 		Targets:    cfg.Targets,
 		Limiter:    rateLimiter,
+		Ingress:    ingressLimiter,
 		Metrics:    metricsCollector,
 		PerKey:     perKeyCollector,
 		SSE:        sseBroker,

--- a/ratelimit/limiter.go
+++ b/ratelimit/limiter.go
@@ -1,0 +1,119 @@
+// Package ratelimit provides a token-bucket rate limiter keyed by an arbitrary
+// string (typically a client IP or API key). It is used to throttle inbound
+// webhook traffic so a single noisy or malicious source cannot flood the bridge.
+package ratelimit
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+)
+
+// Limiter is a token-bucket rate limiter. Each key gets its own bucket that
+// refills at `rate` tokens per second up to `burst` tokens. Safe for concurrent
+// use.
+type Limiter struct {
+	mu      sync.Mutex
+	buckets map[string]*bucket
+	rate    float64       // tokens added per second
+	burst   float64       // bucket capacity
+	ttl     time.Duration // idle buckets older than ttl are evicted
+}
+
+type bucket struct {
+	tokens   float64
+	lastSeen time.Time
+}
+
+// New creates a Limiter allowing `ratePerSec` requests per second per key with a
+// maximum burst of `burst` requests. Returns nil if ratePerSec <= 0 or burst <=
+// 0, which callers treat as "rate limiting disabled".
+func New(ratePerSec float64, burst int) *Limiter {
+	if ratePerSec <= 0 || burst <= 0 {
+		return nil
+	}
+	return &Limiter{
+		buckets: make(map[string]*bucket),
+		rate:    ratePerSec,
+		burst:   float64(burst),
+		ttl:     10 * time.Minute,
+	}
+}
+
+// Allow reports whether a request for the given key may proceed. When denied it
+// also returns how long the caller should wait before the next token is
+// available (suitable for a Retry-After header). A nil Limiter always allows.
+func (l *Limiter) Allow(key string) (allowed bool, retryAfter time.Duration) {
+	if l == nil {
+		return true, 0
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: l.burst, lastSeen: now}
+		l.buckets[key] = b
+	}
+
+	// Refill proportionally to elapsed time since the bucket was last touched.
+	elapsed := now.Sub(b.lastSeen).Seconds()
+	b.tokens = math.Min(l.burst, b.tokens+elapsed*l.rate)
+	b.lastSeen = now
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true, 0
+	}
+
+	// Time until the bucket accrues one full token.
+	wait := time.Duration((1 - b.tokens) / l.rate * float64(time.Second))
+	return false, wait
+}
+
+// StartEviction periodically removes idle buckets so memory does not grow
+// without bound under churning client IPs/keys.
+func (l *Limiter) StartEviction(ctx context.Context, interval time.Duration) {
+	if l == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				l.evictIdle()
+			}
+		}
+	}()
+}
+
+func (l *Limiter) evictIdle() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := time.Now()
+	for key, b := range l.buckets {
+		if now.Sub(b.lastSeen) > l.ttl {
+			delete(l.buckets, key)
+		}
+	}
+}
+
+// Len returns the number of tracked buckets (primarily for tests/metrics).
+func (l *Limiter) Len() int {
+	if l == nil {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.buckets)
+}

--- a/ratelimit/limiter_test.go
+++ b/ratelimit/limiter_test.go
@@ -1,0 +1,102 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNew_DisabledWhenNonPositive(t *testing.T) {
+	if New(0, 5) != nil {
+		t.Error("expected nil limiter for rate <= 0")
+	}
+	if New(5, 0) != nil {
+		t.Error("expected nil limiter for burst <= 0")
+	}
+}
+
+func TestNilLimiter_AlwaysAllows(t *testing.T) {
+	var l *Limiter
+	for i := 0; i < 100; i++ {
+		if ok, _ := l.Allow("any"); !ok {
+			t.Fatal("nil limiter must always allow")
+		}
+	}
+}
+
+func TestAllow_BurstThenDeny(t *testing.T) {
+	// 1 token/sec, burst of 3: first 3 requests pass instantly, 4th is denied.
+	l := New(1, 3)
+	for i := 0; i < 3; i++ {
+		if ok, _ := l.Allow("ip-a"); !ok {
+			t.Fatalf("request %d within burst should be allowed", i+1)
+		}
+	}
+	ok, retryAfter := l.Allow("ip-a")
+	if ok {
+		t.Fatal("4th request should be denied after burst is exhausted")
+	}
+	if retryAfter <= 0 || retryAfter > time.Second {
+		t.Fatalf("retryAfter should be ~1s, got %v", retryAfter)
+	}
+}
+
+func TestAllow_KeysAreIndependent(t *testing.T) {
+	l := New(1, 1)
+	if ok, _ := l.Allow("ip-a"); !ok {
+		t.Fatal("first request for ip-a should pass")
+	}
+	if ok, _ := l.Allow("ip-b"); !ok {
+		t.Fatal("first request for ip-b should pass (independent bucket)")
+	}
+	if ok, _ := l.Allow("ip-a"); ok {
+		t.Fatal("second request for ip-a should be denied")
+	}
+}
+
+func TestAllow_RefillsOverTime(t *testing.T) {
+	// 100 tokens/sec, burst 1: after exhausting, a token refills within ~10ms.
+	l := New(100, 1)
+	if ok, _ := l.Allow("ip-a"); !ok {
+		t.Fatal("first request should pass")
+	}
+	if ok, _ := l.Allow("ip-a"); ok {
+		t.Fatal("immediate second request should be denied")
+	}
+	time.Sleep(20 * time.Millisecond)
+	if ok, _ := l.Allow("ip-a"); !ok {
+		t.Fatal("request after refill window should be allowed")
+	}
+}
+
+func TestEvictIdle_RemovesStaleBuckets(t *testing.T) {
+	l := New(1, 1)
+	l.ttl = 5 * time.Millisecond
+	l.Allow("ip-a")
+	if l.Len() != 1 {
+		t.Fatalf("expected 1 bucket, got %d", l.Len())
+	}
+	time.Sleep(10 * time.Millisecond)
+	l.evictIdle()
+	if l.Len() != 0 {
+		t.Fatalf("expected idle bucket to be evicted, got %d", l.Len())
+	}
+}
+
+func TestStartEviction_StopsOnContextCancel(t *testing.T) {
+	l := New(1, 1)
+	l.ttl = time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	l.StartEviction(ctx, 2*time.Millisecond)
+	l.Allow("ip-a")
+	// Give the eviction goroutine time to run and clear the idle bucket.
+	deadline := time.After(time.Second)
+	for l.Len() != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("eviction goroutine did not clear idle bucket")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+	cancel()
+}


### PR DESCRIPTION
## Context

Code-audit follow-up. The webhook ingress had **no per-source rate limiting**: a client with a valid key (or one hammering invalid keys) could send unlimited requests/sec. The existing Icinga rate limiter only protects Icinga2 *downstream* — the bridge still read bodies, parsed JSON, spawned goroutines, and wrote history/audit for every request, giving an attacker CPU/IO amplification and a brute-force channel against API keys.

## Change

- **`ratelimit` package**: per-key token-bucket limiter (rate + burst), independent buckets per key, idle-bucket eviction to bound memory, `Retry-After` hint on denial.
- **Webhook handler**: enforce a **per-source-IP** limit at the *very top* of `ServeHTTP`, **before authentication**, so invalid-key floods are throttled at the source too. Denied → `429` + `Retry-After`.
- **Config**: `WEBHOOK_RATELIMIT_PER_SEC` (default 50) and `WEBHOOK_RATELIMIT_BURST` (default 100); `PER_SEC=0` disables. Treated as an env-only security control (copied past the dashboard configstore so it can't be silently persisted to 0).

Generous defaults — only actual floods are blocked; normal Grafana/Alertmanager traffic is unaffected.

## Tests
- `ratelimit`: burst/deny, independent keys, time-based refill, idle eviction, ctx-cancel (all `-race`).
- `handler`: `TestWebhook_RateLimit_Returns429AfterBurst` — 429 after burst, `Retry-After` set, independent IP not throttled.

## Docker testenv verification
- Startup log: `Webhook ingress rate limit enabled per_sec=50 burst=100`.
- 400 concurrent POSTs from one IP → **152 passed, 248 got 429**. Normal single requests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)