### PR TITLE
feat: form-based login panel (password-manager friendly) replacing Basic Auth prompt

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// SessionCookieName is the cookie that carries the opaque session token.
+const SessionCookieName = "iaf_session"
+
+// Session holds the credentials of a logged-in dashboard user. The plaintext
+// password is retained so the session middleware can reconstruct an HTTP Basic
+// Auth header, allowing all existing Basic-Auth-based handlers to keep working
+// unchanged. This is consistent with the rest of the app, which already holds
+// admin/RBAC passwords in plaintext in memory and the config store.
+type Session struct {
+	Username string
+	Password string
+	Expiry   time.Time
+}
+
+// SessionStore is an in-memory store of active sessions keyed by an opaque,
+// cryptographically random token. Safe for concurrent use.
+type SessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]Session
+	ttl      time.Duration
+}
+
+// NewSessionStore creates a store whose sessions expire after ttl of inactivity
+// from creation.
+func NewSessionStore(ttl time.Duration) *SessionStore {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	return &SessionStore{
+		sessions: make(map[string]Session),
+		ttl:      ttl,
+	}
+}
+
+// Create stores a new session for the given credentials and returns its token.
+func (s *SessionStore) Create(username, password string) (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	token := hex.EncodeToString(buf)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[token] = Session{
+		Username: username,
+		Password: password,
+		Expiry:   time.Now().Add(s.ttl),
+	}
+	return token, nil
+}
+
+// Get returns the session for a token if it exists and has not expired.
+func (s *SessionStore) Get(token string) (Session, bool) {
+	if token == "" {
+		return Session{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[token]
+	if !ok {
+		return Session{}, false
+	}
+	if time.Now().After(sess.Expiry) {
+		delete(s.sessions, token)
+		return Session{}, false
+	}
+	return sess, true
+}
+
+// Delete removes a session (logout).
+func (s *SessionStore) Delete(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, token)
+}
+
+// StartEviction periodically removes expired sessions so memory does not grow
+// without bound.
+func (s *SessionStore) StartEviction(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.evictExpired()
+			}
+		}
+	}()
+}
+
+func (s *SessionStore) evictExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for token, sess := range s.sessions {
+		if now.After(sess.Expiry) {
+			delete(s.sessions, token)
+		}
+	}
+}
+
+// Len returns the number of active sessions (primarily for tests).
+func (s *SessionStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sessions)
+}

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionStore_CreateAndGet(t *testing.T) {
+	s := NewSessionStore(time.Minute)
+	token, err := s.Create("admin", "secret")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if len(token) != 64 {
+		t.Fatalf("expected 64-char hex token, got %d chars", len(token))
+	}
+
+	sess, ok := s.Get(token)
+	if !ok {
+		t.Fatal("expected session to be retrievable")
+	}
+	if sess.Username != "admin" || sess.Password != "secret" {
+		t.Fatalf("unexpected session contents: %+v", sess)
+	}
+}
+
+func TestSessionStore_TokensAreUnique(t *testing.T) {
+	s := NewSessionStore(time.Minute)
+	t1, _ := s.Create("a", "p")
+	t2, _ := s.Create("a", "p")
+	if t1 == t2 {
+		t.Fatal("expected distinct tokens for separate sessions")
+	}
+}
+
+func TestSessionStore_GetUnknownOrEmpty(t *testing.T) {
+	s := NewSessionStore(time.Minute)
+	if _, ok := s.Get(""); ok {
+		t.Error("empty token must not resolve")
+	}
+	if _, ok := s.Get("deadbeef"); ok {
+		t.Error("unknown token must not resolve")
+	}
+}
+
+func TestSessionStore_Expiry(t *testing.T) {
+	s := NewSessionStore(5 * time.Millisecond)
+	token, _ := s.Create("admin", "secret")
+	if _, ok := s.Get(token); !ok {
+		t.Fatal("session should be valid immediately after creation")
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, ok := s.Get(token); ok {
+		t.Fatal("expired session must not resolve")
+	}
+	if s.Len() != 0 {
+		t.Fatal("expired session should be removed on Get")
+	}
+}
+
+func TestSessionStore_Delete(t *testing.T) {
+	s := NewSessionStore(time.Minute)
+	token, _ := s.Create("admin", "secret")
+	s.Delete(token)
+	if _, ok := s.Get(token); ok {
+		t.Fatal("deleted session must not resolve")
+	}
+}
+
+func TestSessionStore_EvictExpired(t *testing.T) {
+	s := NewSessionStore(5 * time.Millisecond)
+	s.Create("a", "p")
+	s.Create("b", "p")
+	if s.Len() != 2 {
+		t.Fatalf("expected 2 sessions, got %d", s.Len())
+	}
+	time.Sleep(10 * time.Millisecond)
+	s.evictExpired()
+	if s.Len() != 0 {
+		t.Fatalf("expected all sessions evicted, got %d", s.Len())
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,9 @@ type Config struct {
 	AuditLogFile    string
 	AuditLogFormat  string // "json" or "cef"
 
+	// Dashboard login session
+	SessionTTLMinutes int // lifetime of a dashboard login session
+
 	// Dashboard config mode
 	ConfigInDashboard   bool   // if true, config is managed via admin panel
 	ConfigEncryptionKey string // AES key for encrypting secrets (auto-generated if empty)
@@ -215,6 +218,11 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 	if cfg.WebhookRateLimitBurst, err = optInt("WEBHOOK_RATELIMIT_BURST", 100); err != nil {
+		return nil, err
+	}
+
+	// Dashboard login session lifetime (matches the client-side 30 min timeout).
+	if cfg.SessionTTLMinutes, err = optInt("SESSION_TTL_MINUTES", 30); err != nil {
 		return nil, err
 	}
 

--- a/e2e/beauty_panel_test.go
+++ b/e2e/beauty_panel_test.go
@@ -51,13 +51,14 @@ func TestLogin_Invalid(t *testing.T) {
 	var body string
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(baseURL+"/status/beauty?admin=1"),
-		chromedp.WaitVisible(`body`, chromedp.ByQuery),
+		chromedp.WaitVisible(`input[name="password"]`, chromedp.ByQuery),
 		chromedp.OuterHTML(`body`, &body),
 	); err != nil {
 		t.Skipf("render: %v", err)
 	}
-	if !strings.Contains(body, "Enter credentials") {
-		t.Errorf("expected login prompt, got: %.200s", body)
+	// Unauthenticated admin access now redirects to the login form.
+	if !strings.Contains(body, "Command Panel Authentication") {
+		t.Errorf("expected login form, got: %.200s", body)
 	}
 }
 
@@ -240,10 +241,19 @@ func TestRBAC_UserLifecycle(t *testing.T) {
 		}
 	})
 
+	// Don't follow redirects: unauthenticated/denied dashboard access now 303s to
+	// /login, which we want to observe rather than transparently follow to a 200.
 	authGet := func(username, password, path string) int {
+		client := &http.Client{
+			Timeout:       10 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		}
 		req, _ := http.NewRequest("GET", baseURL+path, nil)
 		req.SetBasicAuth(username, password)
-		resp, _ := a.c.Do(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			return 0
+		}
 		resp.Body.Close()
 		return resp.StatusCode
 	}
@@ -274,9 +284,11 @@ func TestRBAC_UserLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("deleted_401", func(t *testing.T) {
-		if c := authGet(user, "viewpass", "/status/beauty?admin=1"); c != 401 {
-			t.Errorf("deleted login: expected 401, got %d", c)
+	t.Run("deleted_denied", func(t *testing.T) {
+		// A deleted user can no longer authenticate: the dashboard redirects them
+		// to the login form (303) instead of granting access.
+		if c := authGet(user, "viewpass", "/status/beauty?admin=1"); c != http.StatusSeeOther {
+			t.Errorf("deleted login: expected 303 redirect to login, got %d", c)
 		}
 	})
 }

--- a/handler/dashboard.go
+++ b/handler/dashboard.go
@@ -2136,7 +2136,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <div class="bar-segment bar-seg-2" id="header-uptime">{{.Uptime}}</div>
       <div class="bar-segment bar-seg-3">IcingaAlertForge{{if .IsAdmin}} <span style="font-size:12px; letter-spacing:2px;">[COMMAND ACCESS - USER: {{.LoggedUser}}]</span>{{end}}</div>
       <div class="bar-segment bar-seg-4">
-        {{if not .IsAdmin}}<a href="/status/beauty?admin=1" style="color:#000;text-decoration:none;">AUTH</a>{{else}}<a href="#" onclick="doLogout();return false;" style="color:#000;text-decoration:none;">LOGOUT</a>{{end}}
+        {{if not .IsAdmin}}<a href="/login" style="color:#000;text-decoration:none;">AUTH</a>{{else}}<a href="#" onclick="doLogout();return false;" style="color:#000;text-decoration:none;">LOGOUT</a>{{end}}
       </div>
       <div class="bar-segment bar-seg-5">{{.Version}}</div>
     </div>
@@ -4242,9 +4242,8 @@ function rbacDeleteUser(username) {
 }
 
 function doLogout() {
-  // Set logout cookie so server forces fresh 401 on next admin login
-  var sec = window.location.protocol === 'https:' ? ';secure' : ''; document.cookie = '_logged_out=1;path=/;samesite=strict' + sec;
-  window.location.href = '/status/beauty';
+  // Server destroys the session, clears the cookie, and redirects to /login.
+  window.location.href = '/status/beauty/logout';
 }
 
 // ── Preserve section on auto-refresh ──
@@ -4637,8 +4636,7 @@ function filterTable(tableId, query, countId) {
   function doLogout() {
     if (countdownInterval) clearInterval(countdownInterval);
     if (popupEl) popupEl.remove();
-    var sec = window.location.protocol === 'https:' ? ';secure' : ''; document.cookie = '_logged_out=1;path=/;samesite=strict' + sec;
-    window.location.href = '/status/beauty';
+    window.location.href = '/status/beauty/logout';
   }
 
   function showWarning() {

--- a/handler/dashboard.go
+++ b/handler/dashboard.go
@@ -2,11 +2,11 @@ package handler
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"icinga-webhook-bridge/httputil"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
 	"sync"
 	"time"
@@ -264,31 +264,13 @@ func (h *DashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Admin mode requires both ?admin=1 query param AND valid credentials.
-	// A "_logged_out" cookie is set on logout to force a fresh 401 prompt
-	// even when the browser re-sends cached Basic Auth credentials.
+	// Admin mode requires both ?admin=1 and a valid login session (or Basic Auth
+	// injected from one). Unauthenticated requests are redirected to the login
+	// form instead of the native browser Basic Auth prompt, so password managers
+	// can autofill.
 	wantAdmin := r.URL.Query().Get("admin") == "1"
 	isAdmin := false
 	if wantAdmin {
-		// If user just logged out, force 401 to get fresh credentials
-		if c, err := r.Cookie("_logged_out"); err == nil && c.Value == "1" {
-			// Clear the logout cookie so next attempt works normally
-			// #nosec G124
-			http.SetCookie(w, &http.Cookie{
-				Name:     "_logged_out",
-				Value:    "",
-				Path:     "/",
-				MaxAge:   -1,
-				HttpOnly: true,
-				Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
-				SameSite: http.SameSiteStrictMode,
-			})
-			w.Header().Set("WWW-Authenticate", `Basic realm="IcingaAlertForge"`)
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprint(w, `<html><body style="background:#000;color:#fc0;font-family:monospace;padding:40px;text-align:center;"><h2>Enter credentials</h2><p>Authenticate to access command panel.</p></body></html>`)
-			return
-		}
 		if h.isAdmin(r) {
 			isAdmin = true
 		} else {
@@ -296,8 +278,7 @@ func (h *DashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if h.Metrics != nil && user != "" {
 				h.Metrics.RecordAuthFailure(r.RemoteAddr, user)
 			}
-			w.Header().Set("WWW-Authenticate", `Basic realm="IcingaAlertForge"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			http.Redirect(w, r, "/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
 			return
 		}
 	}

--- a/handler/dashboard_minimal_test.go
+++ b/handler/dashboard_minimal_test.go
@@ -60,17 +60,20 @@ func TestDashboard_ServeHTTP_Basic(t *testing.T) {
 		}
 	})
 
-	t.Run("GET with admin=1 without creds returns 401", func(t *testing.T) {
+	t.Run("GET with admin=1 without creds redirects to login", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/?admin=1", nil)
 		rr := httptest.NewRecorder()
 		h.ServeHTTP(rr, req)
-		if rr.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rr.Code)
+		if rr.Code != http.StatusSeeOther {
+			t.Errorf("expected 303 redirect, got %d", rr.Code)
+		}
+		if loc := rr.Header().Get("Location"); !strings.HasPrefix(loc, "/login") {
+			t.Errorf("expected redirect to /login, got %q", loc)
 		}
 	})
 }
 
-func TestDashboard_ServeHTTP_AdminLoggedOut(t *testing.T) {
+func TestDashboard_ServeHTTP_UnauthenticatedAdminRedirectsToLogin(t *testing.T) {
 	histLogger, _ := history.NewLogger(filepath.Join(t.TempDir(), "hist.jsonl"), 100)
 	h := &DashboardHandler{
 		Cache:     cache.NewServiceCache(60),
@@ -81,46 +84,15 @@ func TestDashboard_ServeHTTP_AdminLoggedOut(t *testing.T) {
 		AdminPass: "test",
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/?admin=1", nil)
-	req.AddCookie(&http.Cookie{Name: "_logged_out", Value: "1"})
+	req := httptest.NewRequest(http.MethodGet, "/status/beauty?admin=1", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusUnauthorized {
-		t.Errorf("expected 401, got %d", rr.Code)
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d", rr.Code)
 	}
-
-	cookies := rr.Result().Cookies()
-	var found bool
-	for _, c := range cookies {
-		if c.Name == "_logged_out" {
-			found = true
-			if c.Value != "" {
-				t.Errorf("expected empty value for _logged_out cookie, got %q", c.Value)
-			}
-			if c.MaxAge != -1 {
-				t.Errorf("expected MaxAge -1, got %d", c.MaxAge)
-			}
-			if c.Secure {
-				t.Errorf("expected Secure false for non-TLS request, got true")
-			}
-		}
-	}
-	if !found {
-		t.Errorf("expected _logged_out cookie to be cleared")
-	}
-
-	// Test over TLS
-	reqTLS := httptest.NewRequest(http.MethodGet, "/?admin=1", nil)
-	reqTLS.AddCookie(&http.Cookie{Name: "_logged_out", Value: "1"})
-	reqTLS.Header.Set("X-Forwarded-Proto", "https")
-	rrTLS := httptest.NewRecorder()
-	h.ServeHTTP(rrTLS, reqTLS)
-
-	cookiesTLS := rrTLS.Result().Cookies()
-	for _, c := range cookiesTLS {
-		if c.Name == "_logged_out" && !c.Secure {
-			t.Errorf("expected Secure true for TLS request, got false")
-		}
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/login?next=") {
+		t.Errorf("expected redirect to /login with next param, got %q", loc)
 	}
 }

--- a/handler/dashboard_status_test.go
+++ b/handler/dashboard_status_test.go
@@ -269,8 +269,8 @@ func TestDashboard_ServeHTTP_Errors(t *testing.T) {
 		req.SetBasicAuth("wrong", "password")
 		rr := httptest.NewRecorder()
 		h2.ServeHTTP(rr, req)
-		if rr.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401, got %d", rr.Code)
+		if rr.Code != http.StatusSeeOther {
+			t.Errorf("expected 303 redirect to login, got %d", rr.Code)
 		}
 		stats := metric.Snapshot()
 		if stats.FailedAuthTotal == 0 {
@@ -290,13 +290,12 @@ func TestDashboard_ServeHTTP_LogoutAndAdmin(t *testing.T) {
 		Targets:   map[string]config.TargetConfig{},
 	}
 
-	t.Run("logout logic sets 401", func(t *testing.T) {
+	t.Run("unauthenticated admin redirects to login", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/?admin=1", nil)
-		req.AddCookie(&http.Cookie{Name: "_logged_out", Value: "1"})
 		rr := httptest.NewRecorder()
 		h.ServeHTTP(rr, req)
-		if rr.Code != http.StatusUnauthorized {
-			t.Errorf("expected 401 for logout, got %d", rr.Code)
+		if rr.Code != http.StatusSeeOther {
+			t.Errorf("expected 303 redirect to login, got %d", rr.Code)
 		}
 	})
 

--- a/handler/login.go
+++ b/handler/login.go
@@ -79,6 +79,24 @@ func (h *LoginHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, next, http.StatusSeeOther)
 }
 
+// HandleLogout destroys the current session, clears the cookie, and sends the
+// user back to the login form.
+func (h *LoginHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	if c, err := r.Cookie(auth.SessionCookieName); err == nil {
+		h.Sessions.Delete(c.Value)
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   isHTTPS(r),
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}
+
 // valid reports whether the credentials match the primary admin or an RBAC user.
 // Mirrors the Basic Auth check used elsewhere so authorization stays identical.
 func (h *LoginHandler) valid(username, password string) bool {

--- a/handler/login.go
+++ b/handler/login.go
@@ -1,0 +1,174 @@
+package handler
+
+import (
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"icinga-webhook-bridge/auth"
+	"icinga-webhook-bridge/metrics"
+	"icinga-webhook-bridge/rbac"
+)
+
+// LoginHandler serves the form-based login page and processes credential
+// submissions, issuing an opaque session cookie on success. It replaces the
+// native browser Basic Auth prompt so password managers can autofill.
+type LoginHandler struct {
+	Sessions   *auth.SessionStore
+	AdminUser  string
+	AdminPass  string
+	RBAC       *rbac.Manager
+	Metrics    *metrics.Collector
+	Version    string
+	SessionTTL time.Duration
+}
+
+// defaultLoginRedirect is where users land after a successful login.
+const defaultLoginRedirect = "/status/beauty?admin=1"
+
+func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.render(w, http.StatusOK, safeNext(r.URL.Query().Get("next")), "")
+	case http.MethodPost:
+		h.handlePost(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *LoginHandler) handlePost(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4<<10) // 4 KiB is plenty for a login form
+	if err := r.ParseForm(); err != nil {
+		h.render(w, http.StatusBadRequest, defaultLoginRedirect, "Invalid form submission.")
+		return
+	}
+
+	username := r.PostFormValue("username")
+	password := r.PostFormValue("password")
+	next := safeNext(r.PostFormValue("next"))
+
+	if !h.valid(username, password) {
+		slog.Warn("Login failed", "user", username, "remote_addr", r.RemoteAddr)
+		if h.Metrics != nil && username != "" {
+			h.Metrics.RecordAuthFailure(r.RemoteAddr, username)
+		}
+		h.render(w, http.StatusUnauthorized, next, "Invalid credentials.")
+		return
+	}
+
+	token, err := h.Sessions.Create(username, password)
+	if err != nil {
+		slog.Error("Login: failed to create session", "error", err)
+		h.render(w, http.StatusInternalServerError, next, "Could not start session, please retry.")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   isHTTPS(r),
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(h.SessionTTL.Seconds()),
+	})
+	slog.Info("Login successful", "user", username, "remote_addr", r.RemoteAddr)
+	http.Redirect(w, r, next, http.StatusSeeOther)
+}
+
+// valid reports whether the credentials match the primary admin or an RBAC user.
+// Mirrors the Basic Auth check used elsewhere so authorization stays identical.
+func (h *LoginHandler) valid(username, password string) bool {
+	if h.AdminPass == "" {
+		return false
+	}
+	if auth.SecureCompare(username, h.AdminUser) && auth.SecureCompare(password, h.AdminPass) {
+		return true
+	}
+	if h.RBAC != nil {
+		if _, ok := h.RBAC.Authenticate(username, password); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *LoginHandler) render(w http.ResponseWriter, status int, next, errMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	data := loginPageData{Next: next, Error: errMsg, Version: h.Version}
+	if err := loginTemplate.Execute(w, data); err != nil {
+		slog.Error("Login: template render failed", "error", err)
+	}
+}
+
+// safeNext returns next only if it is a safe relative path, preventing open
+// redirects. Anything else falls back to the dashboard.
+func safeNext(next string) string {
+	if next == "" || !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return defaultLoginRedirect
+	}
+	return next
+}
+
+// isHTTPS reports whether the request arrived over TLS, directly or via a proxy.
+func isHTTPS(r *http.Request) bool {
+	return r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
+
+type loginPageData struct {
+	Next    string
+	Error   string
+	Version string
+}
+
+var loginTemplate = template.Must(template.New("login").Parse(loginHTML))
+
+const loginHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>IcingaAlertForge — Login</title>
+<style>
+  :root { --amber:#ff9900; --amber-dim:#cc7a00; --bg:#000; --panel:#1a1a2e; --text:#ffcc99; --err:#cc6666; }
+  * { box-sizing: border-box; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+         background:var(--bg); color:var(--text); font-family:"Helvetica Neue",Arial,sans-serif; }
+  .card { width:360px; max-width:92vw; background:var(--panel); border:2px solid var(--amber);
+          border-radius:18px; padding:32px 28px; box-shadow:0 0 24px rgba(255,153,0,.25); }
+  .title { color:var(--amber); font-size:1.4rem; font-weight:700; letter-spacing:2px;
+           text-transform:uppercase; margin:0 0 4px; text-align:center; }
+  .sub { text-align:center; font-size:.8rem; opacity:.7; margin:0 0 24px; }
+  label { display:block; font-size:.75rem; text-transform:uppercase; letter-spacing:1px;
+          margin:14px 0 6px; color:var(--amber); }
+  input { width:100%; padding:11px 12px; background:#000; color:var(--text);
+          border:1px solid var(--amber-dim); border-radius:8px; font-size:1rem; }
+  input:focus { outline:none; border-color:var(--amber); box-shadow:0 0 8px rgba(255,153,0,.4); }
+  button { width:100%; margin-top:22px; padding:12px; background:var(--amber); color:#000;
+           border:none; border-radius:20px; font-size:1rem; font-weight:700; letter-spacing:1px;
+           text-transform:uppercase; cursor:pointer; }
+  button:hover { background:#ffb340; }
+  .error { margin:14px 0 0; padding:10px; background:rgba(204,102,102,.15);
+           border:1px solid var(--err); border-radius:8px; color:var(--err); font-size:.85rem; text-align:center; }
+  .ver { text-align:center; margin-top:18px; font-size:.7rem; opacity:.5; }
+</style>
+</head>
+<body>
+  <form class="card" method="post" action="/login" autocomplete="on">
+    <h1 class="title">IcingaAlertForge</h1>
+    <p class="sub">Command Panel Authentication</p>
+    <input type="hidden" name="next" value="{{.Next}}">
+    <label for="username">Username</label>
+    <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" autocomplete="current-password" required>
+    {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+    <button type="submit">Sign In</button>
+    {{if .Version}}<div class="ver">{{.Version}}</div>{{end}}
+  </form>
+</body>
+</html>`

--- a/handler/login.go
+++ b/handler/login.go
@@ -66,6 +66,9 @@ func (h *LoginHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Secure is conditional because the bridge legitimately runs over plain HTTP
+	// behind a TLS-terminating proxy; HttpOnly + SameSite are always set.
+	// #nosec G124
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
 		Value:    token,
@@ -85,6 +88,7 @@ func (h *LoginHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	if c, err := r.Cookie(auth.SessionCookieName); err == nil {
 		h.Sessions.Delete(c.Value)
 	}
+	// #nosec G124 -- see note in handlePost; clearing cookie, Secure is conditional.
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
 		Value:    "",

--- a/handler/login_test.go
+++ b/handler/login_test.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"icinga-webhook-bridge/auth"
+)
+
+func testLoginHandler() *LoginHandler {
+	return &LoginHandler{
+		Sessions:   auth.NewSessionStore(30 * time.Minute),
+		AdminUser:  "admin",
+		AdminPass:  "secret",
+		SessionTTL: 30 * time.Minute,
+		Version:    "test",
+	}
+}
+
+func TestLogin_GET_RendersFormWithAutocomplete(t *testing.T) {
+	h := testLoginHandler()
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/login", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	// Password-manager friendliness depends on these autocomplete hints + a real form.
+	for _, want := range []string{`autocomplete="username"`, `autocomplete="current-password"`, `method="post"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("login form missing %q", want)
+		}
+	}
+}
+
+func TestLogin_POST_ValidSetsSessionCookieAndRedirects(t *testing.T) {
+	h := testLoginHandler()
+
+	form := url.Values{"username": {"admin"}, "password": {"secret"}}
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != defaultLoginRedirect {
+		t.Errorf("expected redirect to %q, got %q", defaultLoginRedirect, loc)
+	}
+
+	cookies := rr.Result().Cookies()
+	var token string
+	for _, c := range cookies {
+		if c.Name == auth.SessionCookieName {
+			token = c.Value
+			if !c.HttpOnly {
+				t.Error("session cookie should be HttpOnly")
+			}
+		}
+	}
+	if token == "" {
+		t.Fatal("expected a session cookie to be set")
+	}
+	if _, ok := h.Sessions.Get(token); !ok {
+		t.Error("expected session to exist in store")
+	}
+}
+
+func TestLogin_POST_InvalidRejected(t *testing.T) {
+	h := testLoginHandler()
+
+	form := url.Values{"username": {"admin"}, "password": {"wrong"}}
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == auth.SessionCookieName && c.Value != "" {
+			t.Error("no session cookie should be set on failed login")
+		}
+	}
+	if h.Sessions.Len() != 0 {
+		t.Error("no session should be created on failed login")
+	}
+}
+
+func TestSafeNext_BlocksOpenRedirect(t *testing.T) {
+	cases := map[string]string{
+		"":                 defaultLoginRedirect,
+		"//evil.com":       defaultLoginRedirect,
+		"https://evil.com": defaultLoginRedirect,
+		"/history":         "/history",
+		"/status/beauty":   "/status/beauty",
+	}
+	for in, want := range cases {
+		if got := safeNext(in); got != want {
+			t.Errorf("safeNext(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/handler/login_test.go
+++ b/handler/login_test.go
@@ -94,6 +94,35 @@ func TestLogin_POST_InvalidRejected(t *testing.T) {
 	}
 }
 
+func TestLogout_DestroysSessionAndRedirects(t *testing.T) {
+	h := testLoginHandler()
+	token, _ := h.Sessions.Create("admin", "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/status/beauty/logout", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rr := httptest.NewRecorder()
+	h.HandleLogout(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", rr.Code)
+	}
+	if loc := rr.Header().Get("Location"); loc != "/login" {
+		t.Errorf("expected redirect to /login, got %q", loc)
+	}
+	if _, ok := h.Sessions.Get(token); ok {
+		t.Error("session should be destroyed after logout")
+	}
+	var cleared bool
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == auth.SessionCookieName && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("expected session cookie to be cleared (MaxAge < 0)")
+	}
+}
+
 func TestSafeNext_BlocksOpenRedirect(t *testing.T) {
 	cases := map[string]string{
 		"":                 defaultLoginRedirect,

--- a/handler/session_mw.go
+++ b/handler/session_mw.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"icinga-webhook-bridge/auth"
+)
+
+// SessionAuthMiddleware bridges cookie sessions to the existing Basic-Auth-based
+// handlers: when a request carries a valid session cookie and no Authorization
+// header, it reconstructs an HTTP Basic Auth header from the session credentials.
+// This lets every existing handler keep reading r.BasicAuth() unchanged while
+// users authenticate via the login form. Webhook ingestion is skipped because it
+// uses its own API-key scheme.
+func SessionAuthMiddleware(store *auth.SessionStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if store != nil && r.Header.Get("Authorization") == "" && !strings.HasPrefix(r.URL.Path, "/webhook") {
+			if c, err := r.Cookie(auth.SessionCookieName); err == nil {
+				if sess, ok := store.Get(c.Value); ok {
+					r.SetBasicAuth(sess.Username, sess.Password)
+				}
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/handler/session_mw_test.go
+++ b/handler/session_mw_test.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"icinga-webhook-bridge/auth"
+)
+
+// captureAuth returns a handler that records the username/password it sees via
+// r.BasicAuth(), plus the next handler.
+func captureAuth(seen *struct {
+	user, pass string
+	ok         bool
+}) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen.user, seen.pass, seen.ok = r.BasicAuth()
+	})
+}
+
+func TestSessionMiddleware_InjectsBasicAuthFromSession(t *testing.T) {
+	store := auth.NewSessionStore(time.Minute)
+	token, _ := store.Create("admin", "secret")
+
+	var seen struct {
+		user, pass string
+		ok         bool
+	}
+	mw := SessionAuthMiddleware(store, captureAuth(&seen))
+
+	req := httptest.NewRequest(http.MethodGet, "/status/beauty?admin=1", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !seen.ok || seen.user != "admin" || seen.pass != "secret" {
+		t.Fatalf("expected injected Basic Auth admin/secret, got user=%q pass=%q ok=%v", seen.user, seen.pass, seen.ok)
+	}
+}
+
+func TestSessionMiddleware_NoCookieNoInjection(t *testing.T) {
+	store := auth.NewSessionStore(time.Minute)
+	var seen struct {
+		user, pass string
+		ok         bool
+	}
+	mw := SessionAuthMiddleware(store, captureAuth(&seen))
+
+	mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/status/beauty?admin=1", nil))
+	if seen.ok {
+		t.Fatal("expected no Basic Auth without a session cookie")
+	}
+}
+
+func TestSessionMiddleware_DoesNotOverrideExistingAuth(t *testing.T) {
+	store := auth.NewSessionStore(time.Minute)
+	token, _ := store.Create("admin", "secret")
+	var seen struct {
+		user, pass string
+		ok         bool
+	}
+	mw := SessionAuthMiddleware(store, captureAuth(&seen))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/services", nil)
+	req.SetBasicAuth("apiuser", "apipass") // caller's own credentials
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.user != "apiuser" || seen.pass != "apipass" {
+		t.Fatalf("existing Authorization must be preserved, got %q/%q", seen.user, seen.pass)
+	}
+}
+
+func TestSessionMiddleware_SkipsWebhookPath(t *testing.T) {
+	store := auth.NewSessionStore(time.Minute)
+	token, _ := store.Create("admin", "secret")
+	var seen struct {
+		user, pass string
+		ok         bool
+	}
+	mw := SessionAuthMiddleware(store, captureAuth(&seen))
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen.ok {
+		t.Fatal("webhook path must not receive injected session credentials")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -97,6 +97,8 @@ func main() {
 			// Webhook flood protection (env-only security control)
 			storedCfg.WebhookRateLimitPerSec = cfg.WebhookRateLimitPerSec
 			storedCfg.WebhookRateLimitBurst = cfg.WebhookRateLimitBurst
+			// Dashboard login session lifetime (env-only)
+			storedCfg.SessionTTLMinutes = cfg.SessionTTLMinutes
 			cfg = storedCfg
 			slog.Info("Configuration loaded from dashboard store", "path", cfg.ConfigFilePath)
 		} else {

--- a/main.go
+++ b/main.go
@@ -344,6 +344,20 @@ func main() {
 		RBAC:       rbacManager,
 	}
 
+	// ── Login session store + form login ────────────────────────────
+	sessionTTL := time.Duration(cfg.SessionTTLMinutes) * time.Minute
+	sessionStore := auth.NewSessionStore(sessionTTL)
+	sessionStore.StartEviction(mainCtx, time.Minute)
+	loginHandler := &handler.LoginHandler{
+		Sessions:   sessionStore,
+		AdminUser:  cfg.AdminUser,
+		AdminPass:  cfg.AdminPass,
+		RBAC:       rbacManager,
+		Metrics:    metricsCollector,
+		Version:    version,
+		SessionTTL: sessionTTL,
+	}
+
 	// ── Auth Middleware ─────────────────────────────────────────────
 	requireAuth := func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
@@ -457,6 +471,7 @@ func main() {
 
 	// Core endpoints
 	mux.Handle("/webhook", webhookHandler)
+	mux.Handle("/login", loginHandler)
 	mux.Handle("/status/beauty/events", sseBroker)
 	mux.Handle("/status/beauty", dashboardHandler)
 	mux.HandleFunc("/status/beauty/logout", func(w http.ResponseWriter, r *http.Request) {
@@ -609,6 +624,9 @@ func main() {
 		slog.Warn("ADMIN_PASS not set — admin endpoints and dashboard management will be disabled")
 	}
 
+	// Session middleware: bridges login cookies to Basic-Auth handlers.
+	sessionMux := handler.SessionAuthMiddleware(sessionStore, mux)
+
 	// Security headers middleware
 	secureHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -617,7 +635,7 @@ func main() {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;")
-		mux.ServeHTTP(w, r)
+		sessionMux.ServeHTTP(w, r)
 	})
 
 	server := &http.Server{

--- a/main.go
+++ b/main.go
@@ -474,12 +474,7 @@ func main() {
 	mux.Handle("/login", loginHandler)
 	mux.Handle("/status/beauty/events", sseBroker)
 	mux.Handle("/status/beauty", dashboardHandler)
-	mux.HandleFunc("/status/beauty/logout", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("WWW-Authenticate", `Basic realm="IcingaAlertForge"`)
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, `<html><head><meta http-equiv="refresh" content="1;url=/status/beauty"></head><body>Logged out. Redirecting...</body></html>`)
-	})
+	mux.HandleFunc("/status/beauty/logout", loginHandler.HandleLogout)
 	mux.HandleFunc("/status/beauty/stats", dashboardHandler.HandleStats)
 	mux.HandleFunc("/status/", requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		statusHandler.ServeHTTP(w, r)


### PR DESCRIPTION
## Context

The beauty dashboard / admin panel authenticated via **HTTP Basic Auth**, which triggers the browser's native credential popup. Password managers (1Password, etc.) cannot reliably autofill that dialog, and "logout" was a hack (a `_logged_out` cookie forcing a fresh 401 to defeat cached Basic Auth).

## Change — session-cookie layer that keeps Basic Auth working

A real login **form** with proper `autocomplete` hints, backed by server-side sessions. Existing Basic Auth / API-key auth is untouched (backward compatible).

- **`auth.SessionStore`**: in-memory sessions keyed by a crypto-random opaque token (no signing needed); lazy + periodic expiry; logout deletion.
- **`LoginHandler`** (`/login`): GET renders an LCARS-themed form (`autocomplete="username"` / `current-password`, real `<form method=post>`); POST validates via the *same* admin+RBAC check, creates a session, sets an `HttpOnly`, `SameSite=Lax`, `Secure`-when-TLS cookie, redirects (guarded against open redirects). `HandleLogout` destroys the session, clears the cookie, redirects to `/login`.
- **`SessionAuthMiddleware`**: for a request with a valid session cookie and no `Authorization` header, injects Basic Auth from the session so **every existing Basic-Auth handler works unchanged**. Webhook ingestion is skipped.
- **Dashboard**: unauthenticated `?admin=1` now **303-redirects to `/login`** instead of emitting `WWW-Authenticate` — no more native popup. AUTH link → `/login`; both logout paths → server `/status/beauty/logout`. The `_logged_out` cookie hack is gone.
- **Config**: `SESSION_TTL_MINUTES` (default 30, matching the client-side timeout); preserved across the dashboard config store.

## Tests
- `auth`: session create/get/expiry/delete/eviction, token uniqueness.
- `handler`: login GET form (autocomplete present), POST valid → cookie+redirect, POST invalid → 401, logout destroys session, `safeNext` open-redirect guard, middleware injection / no-cookie / don't-override / skip-webhook. Updated dashboard tests for the redirect behavior.
- `e2e`: updated for the form flow (unauth `?admin=1` → login form; deleted user denied via redirect).
- Full suite green (`./...`).

## Docker testenv verification
- `/login` serves the form with `autocomplete` fields.
- POST `admin/admin123` → 303 + `iaf_session` cookie `Max-Age=1800` (HttpOnly, SameSite=Lax).
- Authed dashboard shows `COMMAND ACCESS - USER: admin`; `/admin/services` via the cookie → 200 (middleware injection).
- Wrong creds → 401. Logout → 303 `/login`, cookie cleared, stale cookie denied.
- **Backward compat**: Basic Auth `-u admin:admin123` → 200; webhook with API key → 200. No `WWW-Authenticate` header anywhere (popup gone).

## Notes / tradeoffs
- Sessions hold the plaintext password to reconstruct Basic Auth for unchanged handlers. This matches the existing design (admin/RBAC passwords are already plaintext in memory and the config store) and avoids a large refactor of every auth-check site.
- Login CSRF is not mitigated with a token (low risk; SameSite=Lax cookie). Can add later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)