### PR TITLE
ci: bump pinned Go to 1.26.4 to clear stdlib vulns (GO-2026-5037/5039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # go directive in go.mod = 1.26
-        go: ['1.26.3']
+        # go directive in go.mod = 1.26; pin a patch that includes the latest
+        # stdlib security fixes (GO-2026-5037, GO-2026-5039 fixed in 1.26.4).
+        go: ['1.26.4']
     steps:
       - uses: actions/checkout@v4
 
@@ -124,11 +125,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v8
         with:
-          name: coverage-1.26.3
+          name: coverage-1.26.4
           path: .
       - uses: codecov/codecov-action@v6
         with:
-          files: ./coverage-1.26.3.out
+          files: ./coverage-1.26.4.out
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: backend

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
       - name: Install and run gosec
         run: |


### PR DESCRIPTION
## Problem

CI's `Go Vulncheck` job (and the govulncheck step in `test (go 1.26.3)`) was red on `main` and every PR — a **pre-existing** failure unrelated to feature code. govulncheck flagged two Go standard-library advisories present in the pinned **go1.26.3** toolchain:

- **GO-2026-5039** — `net/textproto`: arbitrary inputs included in errors without escaping. *Fixed in go1.26.4.*
- **GO-2026-5037** — `crypto/x509`: inefficient candidate hostname parsing. *Fixed in go1.26.4.*

(Triggered via existing code paths in `handler/sse.go` and `icinga/api.go`, not introduced by recent work.)

## Fix

Bump the **hardcoded** `1.26.3` pins to `1.26.4`:
- `ci.yml`: test matrix `go: ['1.26.4']` + coverage artifact name/file.
- `security.yml`: `govulncheck` and `gosec` jobs `go-version: "1.26.4"`.

Workflows that already use `go-version-file: go.mod` (`go 1.26`) resolve to the latest patch automatically and need no change; `go.mod` itself stays at `go 1.26`.

## Verification

YAML structure unchanged (surgical value edits). Once CI runs on this PR, `Go Vulncheck` / `test` should go green. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)