### PR TITLE
feat: manage service pruning from the beauty panel

### DIFF
--- a/configstore/store.go
+++ b/configstore/store.go
@@ -69,6 +69,11 @@ type StoredConfig struct {
 	// Cache
 	CacheTTLMinutes int `json:"cache_ttl_minutes"`
 
+	// Stale-service pruning. AfterDays 0 = disabled. DryRun is a pointer so an
+	// absent value defaults to true (dry-run, safe) rather than false (delete).
+	ServicePruneAfterDays int   `json:"service_prune_after_days"`
+	ServicePruneDryRun    *bool `json:"service_prune_dry_run,omitempty"`
+
 	// Logging
 	LogLevel  string `json:"log_level"`
 	LogFormat string `json:"log_format"`
@@ -291,6 +296,7 @@ func (s *Store) Update(sc StoredConfig) error {
 // MigrateFromEnv creates the initial stored config from a loaded env config.
 func (s *Store) MigrateFromEnv(cfg *config.Config) error {
 	now := time.Now().UTC()
+	dryRun := cfg.ServicePruneDryRun
 	sc := StoredConfig{
 		Version:   1,
 		CreatedAt: now,
@@ -308,6 +314,9 @@ func (s *Store) MigrateFromEnv(cfg *config.Config) error {
 		HistoryMaxEntries: cfg.HistoryMaxEntries,
 
 		CacheTTLMinutes: cfg.CacheTTLMinutes,
+
+		ServicePruneAfterDays: cfg.ServicePruneAfterDays,
+		ServicePruneDryRun:    &dryRun,
 
 		LogLevel:  cfg.LogLevel,
 		LogFormat: cfg.LogFormat,
@@ -418,6 +427,8 @@ func (s *Store) ToConfig(serverPort, serverHost string) *config.Config {
 		HistoryFile:           sc.HistoryFile,
 		HistoryMaxEntries:     sc.HistoryMaxEntries,
 		CacheTTLMinutes:       sc.CacheTTLMinutes,
+		ServicePruneAfterDays: sc.ServicePruneAfterDays,
+		ServicePruneDryRun:    sc.ServicePruneDryRun == nil || *sc.ServicePruneDryRun,
 		LogLevel:              sc.LogLevel,
 		LogFormat:             sc.LogFormat,
 		RateLimitMutate:       sc.RateLimitMutate,

--- a/configstore/store_test.go
+++ b/configstore/store_test.go
@@ -88,6 +88,33 @@ func TestSaveLoad(t *testing.T) {
 	}
 }
 
+func TestToConfig_PruneDryRunDefault(t *testing.T) {
+	s, _ := New(filepath.Join(t.TempDir(), "config.json"), "")
+	base := StoredConfig{
+		Targets:               []TargetStore{{ID: "t1", HostName: "h1"}},
+		ServicePruneAfterDays: 30,
+	}
+
+	// Absent (nil) dry-run must default to true (dry-run / safe), never delete.
+	base.ServicePruneDryRun = nil
+	s.Update(base)
+	cfg := s.ToConfig("8080", "0.0.0.0")
+	if cfg.ServicePruneAfterDays != 30 {
+		t.Errorf("after_days not preserved: %d", cfg.ServicePruneAfterDays)
+	}
+	if !cfg.ServicePruneDryRun {
+		t.Error("nil dry-run must resolve to true (dry-run)")
+	}
+
+	// Explicit false must be honored (real deletion enabled).
+	f := false
+	base.ServicePruneDryRun = &f
+	s.Update(base)
+	if s.ToConfig("8080", "0.0.0.0").ServicePruneDryRun {
+		t.Error("explicit false dry-run must be honored")
+	}
+}
+
 func TestLoadError(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.json")

--- a/handler/dashboard.go
+++ b/handler/dashboard.go
@@ -2744,6 +2744,17 @@ const dashboardHTML = `<!DOCTYPE html>
             </div>
           </div>
 
+          <!-- Service Pruning -->
+          <div class="settings-section">
+            <h3>Service Pruning</h3>
+            <div class="settings-grid">
+              <span class="settings-label">Prune After (days, 0 = off)</span>
+              <input type="number" class="settings-input" id="cfg-prune-days" placeholder="0">
+              <span class="settings-label">Dry Run (log only, no delete)</span>
+              <input type="checkbox" class="settings-input" id="cfg-prune-dryrun">
+            </div>
+          </div>
+
           <!-- Action buttons -->
           <div style="margin-top:20px;display:flex;gap:10px;flex-wrap:wrap;align-items:center;">
             <button class="settings-btn ok" onclick="saveSettings()">Save Configuration</button>
@@ -3803,6 +3814,8 @@ function loadSettings() {
       document.getElementById('cfg-rl-mutate').value = cfg.ratelimit_mutate_max || '';
       document.getElementById('cfg-rl-status').value = cfg.ratelimit_status_max || '';
       document.getElementById('cfg-rl-queue').value = cfg.ratelimit_max_queue || '';
+      document.getElementById('cfg-prune-days').value = cfg.service_prune_after_days || '';
+      document.getElementById('cfg-prune-dryrun').checked = cfg.service_prune_dry_run !== false;
 
       if (cfg.targets) {
         renderTargetCards(cfg.targets);
@@ -3830,7 +3843,9 @@ function saveSettings() {
     log_format: document.getElementById('cfg-log-format').value,
     ratelimit_mutate_max: parseInt(document.getElementById('cfg-rl-mutate').value) || 0,
     ratelimit_status_max: parseInt(document.getElementById('cfg-rl-status').value) || 0,
-    ratelimit_max_queue: parseInt(document.getElementById('cfg-rl-queue').value) || 0
+    ratelimit_max_queue: parseInt(document.getElementById('cfg-rl-queue').value) || 0,
+    service_prune_after_days: parseInt(document.getElementById('cfg-prune-days').value) || 0,
+    service_prune_dry_run: document.getElementById('cfg-prune-dryrun').checked
   };
   if (passVal) { payload.icinga2_pass = passVal; }
   fetch('/admin/settings', {

--- a/handler/settings.go
+++ b/handler/settings.go
@@ -151,6 +151,12 @@ func (h *SettingsHandler) HandlePatchSettings(w http.ResponseWriter, r *http.Req
 	if patch.CacheTTLMinutes > 0 {
 		current.CacheTTLMinutes = patch.CacheTTLMinutes
 	}
+	// Prune: AfterDays applied directly (0 = disable is a valid choice). DryRun
+	// only when present so an omitted field never silently enables deletion.
+	current.ServicePruneAfterDays = patch.ServicePruneAfterDays
+	if patch.ServicePruneDryRun != nil {
+		current.ServicePruneDryRun = patch.ServicePruneDryRun
+	}
 	if patch.LogLevel != "" {
 		current.LogLevel = patch.LogLevel
 	}

--- a/handler/settings_patch_test.go
+++ b/handler/settings_patch_test.go
@@ -19,4 +19,22 @@ func TestSettings_HandlePatchSettings_More(t *testing.T) {
 			t.Errorf("expected 400 for invalid JSON, got %d", rr.Code)
 		}
 	})
+
+	t.Run("prune settings persist", func(t *testing.T) {
+		body := `{"service_prune_after_days":30,"service_prune_dry_run":false}`
+		req := httptest.NewRequest(http.MethodPatch, "/admin/settings", bytes.NewBufferString(body))
+		req.SetBasicAuth("admin", "secret")
+		rr := httptest.NewRecorder()
+		h.HandlePatchSettings(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		got := h.Store.Get()
+		if got.ServicePruneAfterDays != 30 {
+			t.Errorf("after_days not persisted: %d", got.ServicePruneAfterDays)
+		}
+		if got.ServicePruneDryRun == nil || *got.ServicePruneDryRun {
+			t.Errorf("dry_run should persist as false, got %v", got.ServicePruneDryRun)
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -221,8 +221,12 @@ func main() {
 	defer auditLogger.Close()
 
 	// ── Stale-service pruner ───────────────────────────────────────
-	startServicePruner(mainCtx, apiClient, serviceCache, cfg.Targets, auditLogger,
-		cfg.ServicePruneAfterDays, cfg.ServicePruneDryRun)
+	// State is held separately so the pruner can be reconfigured live from the
+	// dashboard; pruneTrigger lets a config reload run a pass immediately.
+	pruneState := &livePruneState{}
+	pruneState.set(cfg.ServicePruneAfterDays, cfg.ServicePruneDryRun, cfg.Targets)
+	pruneTrigger := make(chan struct{}, 1)
+	startServicePruner(mainCtx, apiClient, serviceCache, auditLogger, pruneState, pruneTrigger)
 
 	// ── Health Checker ─────────────────────────────────────────────
 	var healthChecker *health.Checker
@@ -566,6 +570,13 @@ func main() {
 				slog.Error("Failed to update history logger config on reload", "error", err)
 			}
 
+			// Apply pruning config live and run a pass immediately.
+			pruneState.set(newCfg.ServicePruneAfterDays, newCfg.ServicePruneDryRun, newCfg.Targets)
+			select {
+			case pruneTrigger <- struct{}{}:
+			default:
+			}
+
 			slog.Info("Configuration hot-reload complete",
 				"targets", len(newCfg.Targets),
 				"routes", len(newCfg.WebhookRoutes))
@@ -776,15 +787,42 @@ func startCacheResyncEvery(ctx context.Context, apiClient *icinga.APIClient, ser
 // Icinga2 from accumulating long-dead alert artifacts. It runs an initial pass
 // shortly after startup and then daily. In dry-run mode it only logs what it
 // would delete. Disabled when afterDays <= 0.
-func startServicePruner(ctx context.Context, apiClient *icinga.APIClient, serviceCache *cache.ServiceCache, targets map[string]config.TargetConfig, auditLogger *audit.Logger, afterDays int, dryRun bool) {
-	if afterDays <= 0 {
-		slog.Info("Service prune disabled")
-		return
-	}
-	threshold := time.Duration(afterDays) * 24 * time.Hour
-	slog.Info("Service prune enabled", "after_days", afterDays, "dry_run", dryRun)
+// livePruneState holds the pruner's configuration so it can be changed at
+// runtime (e.g. from the dashboard settings panel) without restarting the
+// process. Safe for concurrent use.
+type livePruneState struct {
+	mu        sync.RWMutex
+	afterDays int
+	dryRun    bool
+	targets   map[string]config.TargetConfig
+}
 
+func (s *livePruneState) set(afterDays int, dryRun bool, targets map[string]config.TargetConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.afterDays = afterDays
+	s.dryRun = dryRun
+	s.targets = targets
+}
+
+func (s *livePruneState) get() (afterDays int, dryRun bool, targets map[string]config.TargetConfig) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.afterDays, s.dryRun, s.targets
+}
+
+// startServicePruner runs the stale-service pruner. It reads its configuration
+// from state on every pass, so changes made via the dashboard take effect
+// without a restart. A pass runs shortly after startup, then daily, and also
+// immediately whenever trigger fires (e.g. after a config reload). When pruning
+// is disabled (afterDays <= 0) a pass is a no-op.
+func startServicePruner(ctx context.Context, apiClient *icinga.APIClient, serviceCache *cache.ServiceCache, auditLogger *audit.Logger, state *livePruneState, trigger <-chan struct{}) {
 	runPass := func() {
+		afterDays, dryRun, targets := state.get()
+		if afterDays <= 0 {
+			return // pruning disabled
+		}
+		threshold := time.Duration(afterDays) * 24 * time.Hour
 		for _, target := range sortedTargets(targets) {
 			c, d := pruneStaleManagedServices(apiClient, serviceCache, target.HostName, threshold, dryRun, auditLogger)
 			if c > 0 {
@@ -794,21 +832,23 @@ func startServicePruner(ctx context.Context, apiClient *icinga.APIClient, servic
 		}
 	}
 
+	slog.Info("Service pruner started (config is read live on each pass)")
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
-		// Initial pass shortly after startup for early visibility.
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(time.Minute):
-			runPass()
-		}
+		// Initial pass shortly after startup for early visibility; a config
+		// change (trigger) is honored immediately, even within this window.
+		initial := time.NewTimer(time.Minute)
+		defer initial.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-initial.C:
+				runPass()
 			case <-ticker.C:
+				runPass()
+			case <-trigger:
 				runPass()
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -99,9 +99,6 @@ func main() {
 			storedCfg.WebhookRateLimitBurst = cfg.WebhookRateLimitBurst
 			// Dashboard login session lifetime (env-only)
 			storedCfg.SessionTTLMinutes = cfg.SessionTTLMinutes
-			// Stale-service pruning (env-only operational control)
-			storedCfg.ServicePruneAfterDays = cfg.ServicePruneAfterDays
-			storedCfg.ServicePruneDryRun = cfg.ServicePruneDryRun
 			cfg = storedCfg
 			slog.Info("Configuration loaded from dashboard store", "path", cfg.ConfigFilePath)
 		} else {

--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func pruneMockServer(t *testing.T, listJSON string, deleted chan<- string) *icin
 // pruneTestList builds a ListServices response with one stale-OK, one fresh-OK,
 // one stale-critical, and one unmanaged service.
 func pruneTestList() string {
-	old := float64(time.Now().Add(-2 * time.Hour).Unix())
+	old := float64(time.Now().Add(-48 * time.Hour).Unix())
 	now := float64(time.Now().Unix())
 	return fmt.Sprintf(`{"results":[
 		{"attrs":{"name":"Stale OK","state":0,"vars":{"managed_by":"IcingaAlertingForge"},"last_check_result":{"state":0,"execution_end":%f}}},
@@ -91,6 +91,44 @@ func TestPruneStaleManagedServices_DeletesOnlyStaleOK(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected a DELETE call")
+	}
+}
+
+func TestLivePruneState_SetGet(t *testing.T) {
+	s := &livePruneState{}
+	s.set(30, false, map[string]config.TargetConfig{"a": {HostName: "h1"}})
+	days, dry, targets := s.get()
+	if days != 30 || dry != false || len(targets) != 1 {
+		t.Fatalf("unexpected state: days=%d dry=%v targets=%d", days, dry, len(targets))
+	}
+}
+
+func TestServicePruner_LiveEnableViaTrigger(t *testing.T) {
+	deleted := make(chan string, 4)
+	api := pruneMockServer(t, pruneTestList(), deleted)
+	sc := cache.NewServiceCache(60)
+
+	// Start disabled — no pass should delete anything yet.
+	state := &livePruneState{}
+	targets := map[string]config.TargetConfig{"h": {HostName: "host-a"}}
+	state.set(0, true, targets)
+
+	trigger := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startServicePruner(ctx, api, sc, nil, state, trigger)
+
+	// Reconfigure live: enable with real deletion, then trigger a pass.
+	state.set(1, false, targets)
+	trigger <- struct{}{}
+
+	select {
+	case p := <-deleted:
+		if !strings.Contains(p, "Stale") {
+			t.Errorf("expected to delete the stale service, deleted %q", p)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("live enable + trigger should run a prune pass without restart")
 	}
 }
 


### PR DESCRIPTION
## Context

Follow-up to #208 — the stale-service pruner was **env-only**. This surfaces it in the Settings panel (like Cache TTL / rate limits) **and applies changes live, without a restart**.

## Change

- **configstore**: persist `ServicePruneAfterDays` and `ServicePruneDryRun`. DryRun is a **`*bool`** so an absent value resolves to **true (dry-run / safe)** — a missing field can never silently enable real deletion. `ToConfig` resolves `nil -> true`.
- **settings** (`PATCH /admin/settings`): applies both fields. `AfterDays` directly so **0 = disable** is settable; `DryRun` only when present.
- **dashboard**: new **"Service Pruning"** settings section — days input + dry-run checkbox, with load/save wiring (checkbox defaults checked unless stored value is explicitly `false`).
- **live reload (no restart)**: the pruner reads its config from a thread-safe `livePruneState` on every pass. A config reload updates that state and fires `pruneTrigger`, which runs a pass **immediately**. Enabling/disabling or changing threshold/dry-run from the panel takes effect at once — no restart. The goroutine uses a single select loop (initial timer + daily ticker + trigger), so a trigger is honored even during startup. Disabled (`after_days <= 0`) passes are no-ops.
- **main.go**: drop the env-only copy so the dashboard-stored value wins (env still seeds the first migration).

## Tests
- configstore: `*bool` default resolution (nil → dry-run; explicit false honored).
- settings: PATCH persists both fields.
- `livePruneState` set/get; **live enable via trigger runs a pass and deletes the stale service without restart**.
- Full suite green.

## Docker testenv verification (real Icinga2, no restart)
- Boot log: `Service pruner started (config is read live on each pass)`.
- Created a managed service and backdated its `last_check_result.execution_end` to ~2.3 days ago (stale-OK).
- `PATCH` from the panel (`after_days=1, dry_run=false`) → within the **same second**: `Configuration hot-reload complete` + `deleted stale managed service ... LiveReloadDemo` + `candidates=1 deleted=1`; service then `No objects found` in Icinga2.
- Container `StartedAt` **unchanged** before/after → the change applied **without a restart**.
- Settings panel HTML renders the section; GET/PATCH round-trips the values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)