### PR TITLE
ci: pin Syft version in release SBOM step (fix 504 release failures)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
       - uses: sigstore/cosign-installer@v3
 
       - uses: anchore/sbom-action/download-syft@v0
+        with:
+          # Pin a real, current Syft release. The action's default drifted to a
+          # stale tag (v1.42.3) whose download 504s, failing every release.
+          syft-version: v1.45.1
 
       - uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
## Problem

The **Release** workflow failed on every tag push (`v1.0.18`, `v1.0.19`, and reruns). The `anchore/sbom-action/download-syft@v0` step defaults to a **stale Syft tag `v1.42.3`** whose GitHub download returns **HTTP 504**:

```
[debug] http_download(url=https://github.com/anchore/syft/releases/v1.42.3)
[error] received HTTP status=504 ...
[error] unable to find tag=''
```

Current Syft releases are `v1.42.4`, `v1.43.0`, `v1.44.0`, `v1.45.x` — `v1.42.3` is no longer a healthy asset, so the default consistently fails (not transient — it reproduced across hours and reruns).

## Fix

Pin `syft-version: v1.45.1` (latest stable, verified to exist via the GitHub API) on the `download-syft` step so the download is deterministic and points at a real release. `main` CI is unaffected (Release only runs on tags).

## Note

Releases for `v1.0.18`/`v1.0.19` failed only at this SBOM step — the built code is fine. After merge, a fresh tag will produce a clean release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)