### PR TITLE
fix(dashboard): stop Relay Flow replaying old packets on refresh

### DIFF
--- a/handler/dashboard.go
+++ b/handler/dashboard.go
@@ -4325,17 +4325,9 @@ function switchIPTab(source, tab, btn) {
     orb.addEventListener('animationend', function() { orb.remove(); });
   }
 
-  // Spawn initial orbs from page data (last alerts)
-  var recentAlerts = [
-    {{range .RecentAlerts}}{status: "{{.StatusClass}}"},
-    {{end}}
-  ];
-  var initCount = Math.min(recentAlerts.length, 5);
-  for (var i = 0; i < initCount; i++) {
-    (function(idx) {
-      setTimeout(function() { spawnOrb(recentAlerts[idx].status); }, idx * 600);
-    })(i);
-  }
+  // Orbs are only spawned for live events arriving over SSE — we deliberately
+  // do NOT replay recent history on page load, otherwise old (already-sent)
+  // packets would animate again on every refresh.
 
   // SSE real-time connection
   function incCounter(id) {


### PR DESCRIPTION
## Problem

The **Relay Flow Conduit** animation replayed old packets on every page refresh: the orbs ("balls") for already-sent alerts travelled again each time the page loaded.

## Cause

The flow-animation script seeded up to 5 orbs from the server-rendered `.RecentAlerts` on page load (`Spawn initial orbs from page data`). Every refresh therefore re-animated the last 5 historical alerts.

## Fix

Remove the initial-replay block. Orbs are spawned **only for live events over SSE**. The SSE broker (`handler/sse.go`) keeps no backlog — a new connection only receives events published after it connects — so after a refresh the conduit is calm until a genuinely new packet flows. The live `spawnOrb(data.status)` path is unchanged.

## Verification (Docker testenv)
Served dashboard HTML after rebuild:
- old `var recentAlerts = [` → **0** (removed)
- old `spawnOrb(recentAlerts...)` replay call → **0** (removed)
- live `spawnOrb(data.status...)` → **1** (intact)

`go build`, `gofmt`, and handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)